### PR TITLE
modify dependencies gs-collections to Eclipse Collections 7.1.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
     joptVersion = '4.9'
 
     assertjVersion = '3.3.0'
-    gsCollectionsVersion = '5.0.0'
+    eclipseCollectionsVersion = '7.1.0'
     springRetryVersion = '1.1.2.RELEASE'
     springVersion = '4.2.5.RELEASE'
 
@@ -80,7 +80,7 @@ project(':reactor-kafka-api') {
         testCompile "junit:junit:$junitVersion"
 
         testCompile files("../libs/spring-kafka-test-010.jar")
-        testCompile "com.goldmansachs:gs-collections:$gsCollectionsVersion"
+        testCompile "org.eclipse.collections:eclipse-collections:$eclipseCollectionsVersion"
         testCompile "org.springframework:spring-test:$springVersion"
         testCompile "org.springframework.retry:spring-retry:$springRetryVersion"
         testCompile "org.assertj:assertj-core:$assertjVersion"
@@ -103,7 +103,7 @@ project(':reactor-kafka-tools') {
         testCompile "junit:junit:$junitVersion"
         testCompile project(':reactor-kafka-api').sourceSets.test.output
         testCompile files("../libs/spring-kafka-test-010.jar")
-        testCompile "com.goldmansachs:gs-collections:$gsCollectionsVersion"
+        testCompile "org.eclipse.collections:eclipse-collections:$eclipseCollectionsVersion"
         testCompile "org.springframework:spring-test:$springVersion"
         testCompile "org.springframework.retry:spring-retry:$springRetryVersion"
         testCompile "org.assertj:assertj-core:$assertjVersion"
@@ -127,7 +127,7 @@ project(':reactor-kafka-samples') {
         testCompile "org.apache.kafka:kafka-clients:$kafkaVersion:test"
         testCompile "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion:test"
         testCompile files("../libs/spring-kafka-test-010.jar")
-        testCompile "com.goldmansachs:gs-collections:$gsCollectionsVersion"
+        testCompile "org.eclipse.collections:eclipse-collections:$eclipseCollectionsVersion"
         testCompile "org.springframework:spring-test:$springVersion"
         testCompile "org.springframework.retry:spring-retry:$springRetryVersion"
         testCompile "org.assertj:assertj-core:$assertjVersion"


### PR DESCRIPTION
GS-Collections upgraded to [Eclipse Collections](https://github.com/eclipse/eclipse-collections). I modified its dependencies. But, I think it's no longer use.
Please would you check this PR when you get time? :bow: 
