### PR TITLE
switch to reactor-core and addons 3.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .project
 .classpath
 bin/
+.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ ext {
 
   kafkaVersion = getKafkaVersion
   scalaVersion = '2.11'
-  reactorVersion = '3.0.3.RELEASE'
+  reactorVersion = '3.0.4.RELEASE'
   metricsVersion = '2.2.0'
 
   argparseVersion = '0.5.0'

--- a/reactor-kafka-api/src/test/java/reactor/kafka/receiver/ReceiverTest.java
+++ b/reactor-kafka-api/src/test/java/reactor/kafka/receiver/ReceiverTest.java
@@ -676,7 +676,7 @@ public class ReceiverTest extends AbstractKafkaTest {
             .thenRequest(1)
             .consumeNextWith(r -> TestUtils.sleep(sessionTimeoutMillis + 1000))
             .thenRequest(count - 2)
-            .expectNextCount(count - 1)
+            .expectNextCount(count - 2)
             .expectComplete()
             .verify();
         assertTrue("Commits did not succeed", commitSemaphore.tryAcquire(count, requestTimeoutMillis * count, TimeUnit.MILLISECONDS));


### PR DESCRIPTION
@rajinisivaram `reactor-core` and `reactor-test` 3.0.4 have been released.
This PR also takes a change in `expectNextCount` behavior in reactor-test 3.0.4 into account.