### PR TITLE
Deserializers arguments for KafkaReceiver

### DIFF
--- a/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
+import org.apache.kafka.common.serialization.Deserializer;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.kafka.receiver.internals.ConsumerFactory;
@@ -47,7 +48,22 @@ public interface KafkaReceiver<K, V> {
      * @return new receiver instance
      */
     public static <K, V> KafkaReceiver<K, V> create(ReceiverOptions<K, V> options) {
-        return new DefaultKafkaReceiver<>(ConsumerFactory.INSTANCE, options);
+        return new DefaultKafkaReceiver<>(ConsumerFactory.of(), options);
+    }
+
+    /**
+     * Creates a reactive Kafka receiver with the specified configuration options, key deserializer and value deserializer.
+     *
+     * @param options Configuration options of this receiver. Changes made to the options
+     *        after the receiver is created will not be used by the receiver.
+     *        A subscription using group management or a manual assignment of topic partitions
+     *        must be set on the options instance prior to creating this receiver.
+     * @param keyDeserializer key deserializer to use
+     * @param valueDeserializer value deserializer to use
+     * @return new receiver instance
+     */
+    public static <K, V> KafkaReceiver<K, V> create(ReceiverOptions<K, V> options, Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
+        return new DefaultKafkaReceiver<>(ConsumerFactory.of(keyDeserializer, valueDeserializer), options);
     }
 
     /**

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerFactory.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerFactory.java
@@ -18,16 +18,18 @@ package reactor.kafka.receiver.internals;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 
+import org.apache.kafka.common.serialization.Deserializer;
 import reactor.kafka.receiver.ReceiverOptions;
 
-public class ConsumerFactory {
+public interface ConsumerFactory<K, V>  {
 
-    public static final ConsumerFactory INSTANCE = new ConsumerFactory();
+    Consumer<K, V> createConsumer(ReceiverOptions<K, V> config);
 
-    protected ConsumerFactory() {
+    static <K, V> ConsumerFactory<K, V>  of() {
+        return config -> new KafkaConsumer<>(config.consumerProperties());
     }
 
-    public <K, V> Consumer<K, V> createConsumer(ReceiverOptions<K, V> config) {
-        return new KafkaConsumer<>(config.consumerProperties());
+    static <K,V> ConsumerFactory<K, V> of(Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
+        return config -> new KafkaConsumer<>(config.consumerProperties(), keyDeserializer, valueDeserializer);
     }
 }

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerFactory.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerFactory.java
@@ -29,7 +29,7 @@ public interface ConsumerFactory<K, V>  {
         return config -> new KafkaConsumer<>(config.consumerProperties());
     }
 
-    static <K,V> ConsumerFactory<K, V> of(Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
+    static <K, V> ConsumerFactory<K, V> of(Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
         return config -> new KafkaConsumer<>(config.consumerProperties(), keyDeserializer, valueDeserializer);
     }
 }

--- a/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
@@ -85,7 +85,7 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V>, Consumer
             "beginningOffsets",
             "endOffsets"));
 
-    private final ConsumerFactory consumerFactory;
+    private final ConsumerFactory<K,V> consumerFactory;
     private final ReceiverOptions<K, V> receiverOptions;
     private final List<Flux<? extends Event<?>>> fluxList;
     private final List<Disposable> subscribeDisposables;
@@ -118,7 +118,7 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V>, Consumer
         AUTO_ACK, MANUAL_ACK, ATMOST_ONCE, EXACTLY_ONCE
     }
 
-    public DefaultKafkaReceiver(ConsumerFactory consumerFactory, ReceiverOptions<K, V> receiverOptions) {
+    public DefaultKafkaReceiver(ConsumerFactory<K,V> consumerFactory, ReceiverOptions<K, V> receiverOptions) {
         fluxList = new ArrayList<>();
         subscribeDisposables = new ArrayList<>();
         requestsPending = new AtomicLong();

--- a/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
@@ -85,7 +85,7 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V>, Consumer
             "beginningOffsets",
             "endOffsets"));
 
-    private final ConsumerFactory<K,V> consumerFactory;
+    private final ConsumerFactory<K, V> consumerFactory;
     private final ReceiverOptions<K, V> receiverOptions;
     private final List<Flux<? extends Event<?>>> fluxList;
     private final List<Disposable> subscribeDisposables;
@@ -118,7 +118,7 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V>, Consumer
         AUTO_ACK, MANUAL_ACK, ATMOST_ONCE, EXACTLY_ONCE
     }
 
-    public DefaultKafkaReceiver(ConsumerFactory<K,V> consumerFactory, ReceiverOptions<K, V> receiverOptions) {
+    public DefaultKafkaReceiver(ConsumerFactory<K, V> consumerFactory, ReceiverOptions<K, V> receiverOptions) {
         fluxList = new ArrayList<>();
         subscribeDisposables = new ArrayList<>();
         requestsPending = new AtomicLong();

--- a/src/test/java/reactor/kafka/mock/MockConsumer.java
+++ b/src/test/java/reactor/kafka/mock/MockConsumer.java
@@ -484,7 +484,7 @@ public class MockConsumer extends org.apache.kafka.clients.consumer.MockConsumer
         return String.valueOf(value);
     }
 
-    public static class Pool extends ConsumerFactory {
+    public static class Pool<K,V> implements ConsumerFactory<K,V> {
         private final List<MockConsumer> freeConsumers = new ArrayList<>();
         private final List<MockConsumer> consumersInUse = new ArrayList<>();
         public Pool(List<MockConsumer> freeConsumers) {
@@ -492,7 +492,7 @@ public class MockConsumer extends org.apache.kafka.clients.consumer.MockConsumer
         }
         @SuppressWarnings("unchecked")
         @Override
-        public <K, V> Consumer<K, V> createConsumer(ReceiverOptions<K, V> receiverOptions) {
+        public Consumer<K, V> createConsumer(ReceiverOptions<K, V> receiverOptions) {
             MockConsumer consumer = freeConsumers.remove(0);
             consumer.configure((ReceiverOptions<Integer, String>) receiverOptions);
             consumersInUse.add(consumer);
@@ -504,5 +504,6 @@ public class MockConsumer extends org.apache.kafka.clients.consumer.MockConsumer
         public void addConsumer(MockConsumer consumer) {
             freeConsumers.add(consumer);
         }
+
     }
 }

--- a/src/test/java/reactor/kafka/mock/MockConsumer.java
+++ b/src/test/java/reactor/kafka/mock/MockConsumer.java
@@ -484,7 +484,7 @@ public class MockConsumer extends org.apache.kafka.clients.consumer.MockConsumer
         return String.valueOf(value);
     }
 
-    public static class Pool<K,V> implements ConsumerFactory<K,V> {
+    public static class Pool<K, V> implements ConsumerFactory<K, V> {
         private final List<MockConsumer> freeConsumers = new ArrayList<>();
         private final List<MockConsumer> consumersInUse = new ArrayList<>();
         public Pool(List<MockConsumer> freeConsumers) {

--- a/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
@@ -86,7 +86,7 @@ public class MockReceiverTest {
     private Map<Integer, String> topics;
     private String topic;
     private MockCluster cluster;
-    private MockConsumer.Pool consumerFactory;
+    private MockConsumer.Pool<Integer, String> consumerFactory;
     private MockConsumer consumer;
     private ReceiverOptions<Integer, String> receiverOptions;
 
@@ -109,7 +109,7 @@ public class MockReceiverTest {
                             assignedPartitions.remove(p.topicPartition());
                     });
         consumer = new MockConsumer(cluster);
-        consumerFactory = new MockConsumer.Pool(Arrays.asList(consumer));
+        consumerFactory = new MockConsumer.Pool<>(Arrays.asList(consumer));
 
         for (TopicPartition partition : cluster.partitions())
             receiveStartOffsets.put(partition, 0L);
@@ -1044,7 +1044,7 @@ public class MockReceiverTest {
     public void autoHeartbeat() throws Exception {
         long sessionTimeoutMs = 500;
         consumer = new MockConsumer(cluster);
-        consumerFactory = new MockConsumer.Pool(Arrays.asList(consumer));
+        consumerFactory = new MockConsumer.Pool<>(Arrays.asList(consumer));
         receiverOptions = receiverOptions
                 .consumerProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, String.valueOf(sessionTimeoutMs))
                 .consumerProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "100")

--- a/src/test/java/reactor/kafka/sender/KafkaSenderTest.java
+++ b/src/test/java/reactor/kafka/sender/KafkaSenderTest.java
@@ -517,7 +517,7 @@ public class KafkaSenderTest extends AbstractKafkaTest {
     private Consumer<Integer, String> createConsumer() throws Exception {
         String groupId = testName.getMethodName();
         Map<String, Object> consumerProps = consumerProps(groupId);
-        Consumer<Integer, String> consumer = ConsumerFactory.INSTANCE.createConsumer(ReceiverOptions.<Integer, String>create(consumerProps));
+        Consumer<Integer, String> consumer = ConsumerFactory.<Integer, String>of().createConsumer(ReceiverOptions.create(consumerProps));
         consumer.subscribe(Collections.singletonList(topic));
         consumer.poll(requestTimeoutMillis);
         return consumer;

--- a/src/test/java/reactor/kafka/sender/internals/MockTransactionTest.java
+++ b/src/test/java/reactor/kafka/sender/internals/MockTransactionTest.java
@@ -70,7 +70,7 @@ public class MockTransactionTest {
     private int maxPollRecords = 10;
 
     private MockCluster cluster;
-    private MockConsumer.Pool consumerFactory;
+    private MockConsumer.Pool<Integer, String> consumerFactory;
     private ReceiverOptions<Integer, String> receiverOptions;
     private KafkaReceiver<Integer, String> receiver;
     private MockProducer producer;
@@ -95,7 +95,7 @@ public class MockTransactionTest {
                             assignedPartitions.remove(p.topicPartition());
                     })
                 .subscription(Collections.singleton(srcTopic));
-        consumerFactory = new MockConsumer.Pool(Arrays.asList(new MockConsumer(cluster), new MockConsumer(cluster)));
+        consumerFactory = new MockConsumer.Pool<>(Arrays.asList(new MockConsumer(cluster), new MockConsumer(cluster)));
         receiver = new DefaultKafkaReceiver<Integer, String>(consumerFactory, receiverOptions);
 
         for (TopicPartition partition : cluster.partitions())


### PR DESCRIPTION
I'd need to be able to give key and value deserializers directly as arguments to the KafkaReceiver.create method instead of the ReceiverOptions. This is because something like Protobuf generated classes have a static parseFrom method to deserialize objects for which I cannot create a generic deserializer. Instead I'd want to create the deserializers through a factory like the one below:

```
import io.vavr.CheckedFunction1;
import org.apache.kafka.common.serialization.Deserializer;

import java.util.Map;

public class ProtobufDeserializerFactory {

    public static <T> Deserializer<T> of(CheckedFunction1<byte[], T> f) {
        return new Deserializer<T>() {
            @Override
            public void configure(Map<String, ?> configs, boolean isKey) {}

            @Override
            public T deserialize(String topic, byte[] data) {
                try {
                    return f.apply(data);
                } catch (Throwable throwable) {
                    throw new RuntimeException(throwable);
                }
            }

            @Override
            public void close() {}
        };
    }
}
```
and use them a so:

```
KafkaReceiver
    .create(options, 
            new StringDeserializer(), 
            ProtobufDeserializerFactory.of(Definitions.ExampleMessage::parseFrom))
    .receive();
```
In my case this is not required for serializers although for symmetry reasons this could also be implemented in KafkaSender.