### PR TITLE
#29 fix OverflowException in Flux.interval when kafka broker is unavailable for some time

### DIFF
--- a/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
@@ -321,7 +321,8 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V>, Consumer
         Duration commitInterval = receiverOptions.commitInterval();
         if ((ackMode == AckMode.AUTO_ACK || ackMode == AckMode.MANUAL_ACK) && !commitInterval.isZero()) {
             Flux<CommitEvent> periodicCommitFlux = Flux.interval(receiverOptions.commitInterval())
-                             .map(i -> commitEvent.periodicEvent());
+                                                       .onBackpressureLatest()
+                                                       .map(i -> commitEvent.periodicEvent());
             fluxList.add(periodicCommitFlux);
         }
 


### PR DESCRIPTION
Added `onBackpressureLatest` to skip emitted intervals during a hang