### PR TITLE
Maintenance update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ With Gradle from repo.spring.io:
     }
 
     dependencies {
-      //compile "io.projectreactor.kafka:reactor-kafka:1.0.1.BUILD-SNAPSHOT"
-      compile "io.projectreactor.kafka:reactor-kafka:1.0.0.RELEASE"
+      //compile "io.projectreactor.kafka:reactor-kafka:1.1.1.BUILD-SNAPSHOT"
+      compile "io.projectreactor.kafka:reactor-kafka:1.1.0.RELEASE"
     }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,12 +29,12 @@ plugins {
 }
 
 ext {
-  gradleVersion = '4.9'
+  gradleVersion = '4.10'
   gradleScriptDir = "${rootProject.projectDir}/gradle"
 
-  kafkaVersion = '1.0.2'
+  kafkaVersion = '2.0.0'
   scalaVersion = '2.11'
-  reactorVersion = '3.1.9.RELEASE'
+  reactorVersion = '3.2.0.RELEASE'
   metricsVersion = '2.2.0'
 
   argparseVersion = '0.5.0'
@@ -42,7 +42,7 @@ ext {
 
   slf4jVersion = '1.7.25'
   junitVersion = '4.12'
-  zkVersion = "3.4.12"
+  zkVersion = "3.4.13"
   powermockVersion = '1.7.4'
 
   javadocLinks = ["http://docs.oracle.com/javase/8/docs/api/",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.2.BUILD-SNAPSHOT
+version=1.1.0.BUILD-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/docs/asciidoc/getting-started.adoc
+++ b/src/docs/asciidoc/getting-started.adoc
@@ -7,7 +7,7 @@ You need Java JRE installed (Java 8 or later).
 
 You need http://kafka.apache.org[Apache Kafka] installed (1.0.0 or later). Kafka can be downloaded
 from https://kafka.apache.org/downloads.html. Note that the Apache Kafka client library used with
-Reactor Kafka should be 1.0.2 or later and the broker version should be 0.11.0.0 or later.
+Reactor Kafka should be 2.0.0 or later and the broker version should be 1.0.0 or higher.
 
 === Quick Start
 
@@ -16,14 +16,14 @@ consumer. Instructions to set up multi-broker clusters are available http://kafk
 
 ==== Start Kafka
 
-If you haven't yet downloaded Kafka, download Kafka version https://www.apache.org/dyn/closer.cgi?path=/kafka/1.0.2/kafka_2.11-1.0.2.tgz[1.0.2] or later.
+If you haven't yet downloaded Kafka, download Kafka version https://www.apache.org/dyn/closer.cgi?path=/kafka/2.0.0/kafka_2.11-2.0.0.tgz[2.0.0] or higher.
 
 Unzip the release and set KAFKA_DIR to the installation directory. For example,
 
 [source]
 --------
-> tar -zxf kafka_2.11-1.0.2.tgz -C /opt
-> export KAFKA_DIR=/opt/kafka_2.11-1.0.2
+> tar -zxf kafka_2.11-2.0.0.tgz -C /opt
+> export KAFKA_DIR=/opt/kafka_2.11-2.0.0
 --------
 
 Start a single-node Zookeeper instance using the Zookeeper installation included in the Kafka download:
@@ -53,9 +53,9 @@ Check that Kafka topic was created successfully:
 [source]
 --------
 > $KAFKA_DIR/bin/kafka-topics.sh --zookeeper localhost:2181 --describe
-Topic:demo-topic	PartitionCount:2	ReplicationFactor:1	Configs:
-	Topic: demo-topic	Partition: 0	Leader: 0	Replicas: 0	Isr: 0
-	Topic: demo-topic	Partition: 1	Leader: 0	Replicas: 0	Isr: 0
+Topic: demo-topic	PartitionCount:2		ReplicationFactor:1	Configs:
+Topic: demo-topic	Partition: 0	Leader: 0	Replicas: 0		Isr: 0
+Topic: demo-topic	Partition: 1	Leader: 0	Replicas: 0		Isr: 0
 --------
 
 
@@ -160,7 +160,7 @@ For gradle:
 [source]
 --------
 dependencies {
-    compile "io.projectreactor.kafka:reactor-kafka:1.0.1.RELEASE"
+    compile "io.projectreactor.kafka:reactor-kafka:1.1.0.RELEASE"
 }
 --------
 
@@ -172,7 +172,7 @@ For maven:
 <dependency>
     <groupId>io.projectreactor.kafka</groupId>
     <artifactId>reactor-kafka</artifactId>
-    <version>1.0.1.RELEASE</version>
+    <version>1.1.0.RELEASE</version>
 </dependency>
 --------
 

--- a/src/docs/asciidoc/index.asciidoc
+++ b/src/docs/asciidoc/index.asciidoc
@@ -1,6 +1,6 @@
 = Reactor Kafka Reference Guide
 Rajini Sivaram, Mark Pollack, Oleh Dokuka
-:appversion: 1.0.1.RELEASE
+:appversion: 1.1.0.RELEASE
 ifndef::host-github[:ext-relative: {outfilesuffix}]
 {appversion}
 :doctype: book

--- a/src/docs/asciidoc/new.adoc
+++ b/src/docs/asciidoc/new.adoc
@@ -13,3 +13,11 @@
 significant issues
 * Performance tuning and optimization of Reactor 3 usage 🤟
 
+=== What's new in Reactor Kafka 1.1.0.RELEASE
+
+This release is a maintenance release. The following are the major updates:
+
+* Align with Reactor 3.2.0.RELEASE version
+* Update to Apache Kafka 2.0.0 client
+* Stabilize test-suite
+

--- a/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
@@ -1,0 +1,609 @@
+/*
+ * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.kafka.receiver;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.serialization.Deserializer;
+import reactor.core.scheduler.Scheduler;
+
+public class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
+
+    private final Map<String, Object> properties;
+    private final List<Consumer<Collection<ReceiverPartition>>> assignListeners;
+    private final List<Consumer<Collection<ReceiverPartition>>> revokeListeners;
+
+    private final Deserializer<K> keyDeserializer;
+    private final Deserializer<V> valueDeserializer;
+
+    private final Duration pollTimeout;
+    private final Duration closeTimeout;
+    private final Duration commitInterval;
+    private final int commitBatchSize;
+    private final int atmostOnceCommitAheadSize;
+    private final int maxCommitAttempts;
+    private final Collection<String> subscribeTopics;
+    private final Collection<TopicPartition> assignTopicPartitions;
+    private final Pattern subscribePattern;
+    private final Supplier<Scheduler> schedulerSupplier;
+
+    ImmutableReceiverOptions(ReceiverOptions<K, V> options) {
+        this(
+            options.consumerProperties(),
+            options.assignListeners(),
+            options.revokeListeners(),
+            options.keyDeserializer(),
+            options.valueDeserializer(),
+            options.pollTimeout(),
+            options.closeTimeout(),
+            options.commitInterval(),
+            options.commitBatchSize(),
+            options.atmostOnceCommitAheadSize(),
+            options.maxCommitAttempts(),
+            options.subscriptionTopics(),
+            options.assignment(),
+            options.subscriptionPattern(),
+            options.schedulerSupplier()
+        );
+    }
+
+    ImmutableReceiverOptions(
+        Map<String, Object> properties,
+        List<Consumer<Collection<ReceiverPartition>>> assignListeners,
+        List<Consumer<Collection<ReceiverPartition>>> revokeListeners,
+        Deserializer<K> deserializer,
+        Deserializer<V> valueDeserializer,
+        Duration pollTimeout,
+        Duration closeTimeout,
+        Duration commitInterval,
+        int commitBatchSize,
+        int atmostOnceCommitAheadSize,
+        int maxCommitAttempts,
+        Collection<String> topics,
+        Collection<TopicPartition> partitions,
+        Pattern pattern,
+        Supplier<Scheduler> supplier
+    ) {
+        this.properties = new HashMap<>(properties);
+        this.assignListeners = new ArrayList<>(assignListeners);
+        this.revokeListeners = new ArrayList<>(revokeListeners);
+        this.keyDeserializer = deserializer;
+        this.valueDeserializer = valueDeserializer;
+        this.pollTimeout = pollTimeout;
+        this.closeTimeout = closeTimeout;
+        this.commitInterval = commitInterval;
+        this.commitBatchSize = commitBatchSize;
+        this.atmostOnceCommitAheadSize = atmostOnceCommitAheadSize;
+        this.maxCommitAttempts = maxCommitAttempts;
+        this.subscribeTopics = topics == null ? null : new HashSet<>(topics);
+        this.assignTopicPartitions = partitions == null ? null : new HashSet<>(partitions);
+        this.subscribePattern = pattern;
+        this.schedulerSupplier = supplier;
+    }
+
+    @Override
+    public Map<String, Object> consumerProperties() {
+        return new HashMap<>(properties);
+    }
+
+    @Override
+    public Object consumerProperty(String name) {
+        return properties.get(name);
+    }
+
+    @Override
+    public ReceiverOptions<K, V> consumerProperty(String name, Object newValue) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(newValue);
+
+        HashMap<String, Object> properties = new HashMap<>(this.properties);
+        properties.put(name, newValue);
+
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public ReceiverOptions<K, V> withKeyDeserializer(Deserializer<K> keyDeserializer) {
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                Objects.requireNonNull(keyDeserializer),
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public Deserializer<K> keyDeserializer() {
+        return keyDeserializer;
+    }
+
+    @Override
+    public ReceiverOptions<K, V> withValueDeserializer(Deserializer<V> valueDeserializer) {
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                Objects.requireNonNull(valueDeserializer),
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public Deserializer<V> valueDeserializer() {
+        return valueDeserializer;
+    }
+
+    @Override
+    public Duration pollTimeout() {
+        return pollTimeout;
+    }
+
+    @Override
+    public ReceiverOptions<K, V> pollTimeout(Duration timeout) {
+        if (timeout == null || timeout.isNegative())
+            throw new IllegalArgumentException("Close timeout must be >= 0");
+
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                Objects.requireNonNull(timeout),
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public Duration closeTimeout() {
+        return closeTimeout;
+    }
+
+    @Override
+    public ReceiverOptions<K, V> closeTimeout(Duration timeout) {
+        if (timeout == null || timeout.isNegative())
+            throw new IllegalArgumentException("Close timeout must be >= 0");
+
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                Objects.requireNonNull(timeout),
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public ReceiverOptions<K, V> addAssignListener(Consumer<Collection<ReceiverPartition>> onAssign) {
+        Objects.requireNonNull(onAssign);
+
+        ArrayList<Consumer<Collection<ReceiverPartition>>> assignListeners = new ArrayList<>(this.assignListeners);
+        assignListeners.add(onAssign);
+
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public ReceiverOptions<K, V> addRevokeListener(Consumer<Collection<ReceiverPartition>> onRevoke) {
+        Objects.requireNonNull(onRevoke);
+
+        ArrayList<Consumer<Collection<ReceiverPartition>>> revokeListeners = new ArrayList<>(this.revokeListeners);
+        revokeListeners.add(onRevoke);
+
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public ReceiverOptions<K, V> clearAssignListeners() {
+        return new ImmutableReceiverOptions<>(
+                properties,
+                new ArrayList<>(),
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public ReceiverOptions<K, V> clearRevokeListeners() {
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                new ArrayList<>(),
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public List<Consumer<Collection<ReceiverPartition>>> assignListeners() {
+        return new ArrayList<>(assignListeners);
+    }
+
+    @Override
+    public List<Consumer<Collection<ReceiverPartition>>> revokeListeners() {
+        return new ArrayList<>(revokeListeners);
+    }
+
+    @Override
+    public ReceiverOptions<K, V> subscription(Collection<String> topics) {
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                Objects.requireNonNull(topics),
+                null,
+                null,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public ReceiverOptions<K, V> subscription(Pattern pattern) {
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                null,
+                null,
+                Objects.requireNonNull(pattern),
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public ReceiverOptions<K, V> assignment(Collection<TopicPartition> partitions) {
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                null,
+                Objects.requireNonNull(partitions),
+                null,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public Collection<TopicPartition> assignment() {
+        return assignTopicPartitions == null ? null : new HashSet<>(assignTopicPartitions);
+    }
+
+    @Override
+    public Collection<String> subscriptionTopics() {
+        return subscribeTopics == null ? null : new HashSet<>(subscribeTopics);
+    }
+
+    @Override
+    public Pattern subscriptionPattern() {
+        return subscribePattern;
+    }
+
+    @Override
+    public String groupId() {
+        return (String) consumerProperty(ConsumerConfig.GROUP_ID_CONFIG);
+    }
+
+    @Override
+    public Duration heartbeatInterval() {
+        long defaultValue = 3000; // Kafka default
+        long heartbeatIntervalMs = getLongOption(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, defaultValue);
+        return Duration.ofMillis(heartbeatIntervalMs);
+    }
+
+    @Override
+    public Duration commitInterval() {
+        return commitInterval;
+    }
+
+    @Override
+    public ReceiverOptions<K, V> commitInterval(Duration commitInterval) {
+        if (commitInterval == null || commitInterval.isNegative())
+            throw new IllegalArgumentException("Commit interval must be >= 0");
+
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public int commitBatchSize() {
+        return commitBatchSize;
+    }
+
+    @Override
+    public ReceiverOptions<K, V> commitBatchSize(int commitBatchSize) {
+        if (commitBatchSize < 0)
+            throw new IllegalArgumentException("Commit batch size must be >= 0");
+
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public int atmostOnceCommitAheadSize() {
+        return atmostOnceCommitAheadSize;
+    }
+
+    @Override
+    public ReceiverOptions<K, V> atmostOnceCommitAheadSize(int commitAheadSize) {
+        if (commitAheadSize < 0)
+            throw new IllegalArgumentException("Commit ahead size must be >= 0");
+
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                commitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public int maxCommitAttempts() {
+        return maxCommitAttempts;
+    }
+
+    @Override
+    public ReceiverOptions<K, V> maxCommitAttempts(int maxAttempts) {
+        if (maxAttempts < 0)
+            throw new IllegalArgumentException("the number of attempts must be >= 0");
+
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier
+        );
+    }
+
+    @Override
+    public Supplier<Scheduler> schedulerSupplier() {
+        return schedulerSupplier;
+    }
+
+    @Override
+    public ReceiverOptions<K, V> schedulerSupplier(Supplier<Scheduler> schedulerSupplier) {
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                Objects.requireNonNull(schedulerSupplier)
+        );
+    }
+
+    private long getLongOption(String optionName, long defaultValue) {
+        Objects.requireNonNull(optionName);
+
+        Object value = consumerProperty(optionName);
+        long optionValue = 0;
+        if (value != null) {
+            if (value instanceof Long)
+                optionValue = (Long) value;
+            else if (value instanceof String)
+                optionValue = Long.parseLong((String) value);
+            else
+                throw new ConfigException("Invalid value " + value);
+        } else
+            optionValue = defaultValue;
+        return optionValue;
+    }
+}

--- a/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
@@ -33,7 +33,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.Deserializer;
 import reactor.core.scheduler.Scheduler;
 
-public class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
+class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
 
     private final Map<String, Object> properties;
     private final List<Consumer<Collection<ReceiverPartition>>> assignListeners;

--- a/src/main/java/reactor/kafka/receiver/MutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/MutableReceiverOptions.java
@@ -44,7 +44,7 @@ import reactor.core.scheduler.Schedulers;
  * deleted in 3.x version
  */
 @Deprecated
-public class MutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
+class MutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
 
     private static final Duration DEFAULT_POLL_TIMEOUT = Duration.ofMillis(100);
     private static final int DEFAULT_MAX_COMMIT_ATTEMPTS = 100;

--- a/src/main/java/reactor/kafka/receiver/MutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/MutableReceiverOptions.java
@@ -1,0 +1,544 @@
+/*
+ * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.kafka.receiver;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.serialization.Deserializer;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Configuration properties for Reactive Kafka {@link KafkaReceiver} and its underlying {@link KafkaConsumer}.
+ *
+ * @deprecated deprecated in favor of {@link ImmutableReceiverOptions} and will be
+ * deleted in 3.x version
+ */
+@Deprecated
+public class MutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
+
+    private static final Duration DEFAULT_POLL_TIMEOUT = Duration.ofMillis(100);
+    private static final int DEFAULT_MAX_COMMIT_ATTEMPTS = 100;
+
+    private final Map<String, Object> properties;
+    private final List<Consumer<Collection<ReceiverPartition>>> assignListeners;
+    private final List<Consumer<Collection<ReceiverPartition>>> revokeListeners;
+
+    private Deserializer<K> keyDeserializer;
+    private Deserializer<V> valueDeserializer;
+
+    private Duration pollTimeout;
+    private Duration closeTimeout;
+    private Duration commitInterval;
+    private int commitBatchSize;
+    private int atmostOnceCommitAheadSize;
+    private int maxCommitAttempts;
+    private Collection<String> subscribeTopics;
+    private Collection<TopicPartition> assignTopicPartitions;
+    private Pattern subscribePattern;
+    private Supplier<Scheduler> schedulerSupplier;
+
+    MutableReceiverOptions() {
+        this(new HashMap<>());
+    }
+
+    MutableReceiverOptions(Properties properties) {
+        this(
+            properties
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                    e -> e.getKey().toString(),
+                    Map.Entry::getValue
+                ))
+        );
+    }
+
+    MutableReceiverOptions(Map<String, Object> configProperties) {
+        properties = new HashMap<>(configProperties);
+        assignListeners = new ArrayList<>();
+        revokeListeners = new ArrayList<>();
+
+        pollTimeout = DEFAULT_POLL_TIMEOUT;
+        closeTimeout = Duration.ofNanos(Long.MAX_VALUE);
+        commitInterval = Duration.ofMillis(5000); // Kafka default
+        commitBatchSize = 0;
+        maxCommitAttempts = DEFAULT_MAX_COMMIT_ATTEMPTS;
+        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        schedulerSupplier = Schedulers::parallel;
+    }
+
+    /**
+     * Returns the configuration properties of the underlying {@link KafkaConsumer}.
+     * @return options to configure for Kafka consumer.
+     */
+    @Override
+    public Map<String, Object> consumerProperties() {
+        return properties;
+    }
+
+    /**
+     * Returns the {@link KafkaConsumer} configuration property value for the specified option name.
+     * @return Kafka consumer configuration option value
+     */
+    @Override
+    public Object consumerProperty(String name) {
+        return properties.get(name);
+    }
+
+    /**
+     * Sets {@link KafkaConsumer} configuration property to the specified value.
+     * @return options instance with updated Kafka consumer property
+     */
+    @Override
+    public ReceiverOptions<K, V> consumerProperty(String name, Object newValue) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(newValue);
+
+        this.properties.put(name, newValue);
+        return this;
+    }
+
+    /**
+     * Set a concrete deserializer instant to be used by the {@link KafkaConsumer} for keys. Overrides any setting of the
+     * {@link ConsumerConfig#KEY_DESERIALIZER_CLASS_CONFIG} property.
+     * @param keyDeserializer key deserializer to use in the consumer
+     * @return options instance with new key deserializer
+     */
+    @Override
+    public ReceiverOptions<K, V> withKeyDeserializer(Deserializer<K> keyDeserializer) {
+        this.keyDeserializer = Objects.requireNonNull(keyDeserializer);
+        return this;
+    }
+
+    /**
+     *
+     * Returns optionally a deserializer witch is used by {@link KafkaConsumer} for key deserialization.
+     * @return configured key deserializer instant
+     */
+    @Override
+    public Deserializer<K> keyDeserializer() {
+        return keyDeserializer;
+    }
+
+    /**
+     * Set a concrete deserializer instant to be used by the {@link KafkaConsumer} for values. Overrides any setting of the
+     * {@link ConsumerConfig#VALUE_DESERIALIZER_CLASS_CONFIG} property.
+     * @param valueDeserializer value deserializer to use in the consumer
+     * @return options instance with new value deserializer
+     */
+    @Override
+    public ReceiverOptions<K, V> withValueDeserializer(Deserializer<V> valueDeserializer) {
+        this.valueDeserializer = Objects.requireNonNull(valueDeserializer);
+        return this;
+    }
+
+    /**
+     *
+     * Returns optionally a deserializer witch is used by {@link KafkaConsumer} for value deserialization.
+     * @return configured value deserializer instant
+     */
+    @Override
+    public Deserializer<V> valueDeserializer() {
+        return valueDeserializer;
+    }
+
+    /**
+     * Returns the timeout for each {@link KafkaConsumer#poll(long)} operation.
+     * @return poll timeout duration
+     */
+    @Override
+    public Duration pollTimeout() {
+        return pollTimeout;
+    }
+
+    /**
+     * Sets the timeout for each {@link KafkaConsumer#poll(long)} operation. Since
+     * the underlying Kafka consumer is not thread-safe, long poll intervals may delay
+     * commits and other operations invoked using {@link KafkaReceiver#doOnConsumer(java.util.function.Function)}.
+     * Very short timeouts may reduce batching and increase load on the broker,
+     * @return options instance with new poll timeout
+     */
+    @Override
+    public ReceiverOptions<K, V> pollTimeout(Duration timeout) {
+        if (timeout == null || timeout.isNegative())
+            throw new IllegalArgumentException("Close timeout must be >= 0");
+
+        this.pollTimeout = Objects.requireNonNull(timeout);
+        return this;
+    }
+
+    /**
+     * Returns timeout for graceful shutdown of {@link KafkaConsumer}.
+     * @return close timeout duration
+     */
+    @Override
+    public Duration closeTimeout() {
+        return closeTimeout;
+    }
+
+    /**
+     * Sets timeout for graceful shutdown of {@link KafkaConsumer}.
+     * @return options instance with new close timeout
+     */
+    @Override
+    public ReceiverOptions<K, V> closeTimeout(Duration timeout) {
+        if (timeout == null || timeout.isNegative())
+            throw new IllegalArgumentException("Close timeout must be >= 0");
+
+        this.closeTimeout = Objects.requireNonNull(timeout);
+        return this;
+    }
+
+    /**
+     * Adds a listener for partition assignments. Applications can use this listener to seek
+     * to different offsets of the assigned partitions using any of the seek methods in
+     * {@link ReceiverPartition}. When group management is used, assign listeners are invoked
+     * after every rebalance operation. With manual partition assignment using {@link MutableReceiverOptions#assignment()},
+     * assign listeners are invoked once when the receive Flux is subscribed to.
+     * @return options instance with new partition assignment listener
+     */
+    @Override
+    public ReceiverOptions<K, V> addAssignListener(Consumer<Collection<ReceiverPartition>> onAssign) {
+        assignListeners.add(Objects.requireNonNull(onAssign));
+        return this;
+    }
+
+    /**
+     * Adds a listener for partition revocations. Applications can use this listener to commit
+     * offsets if required. Acknowledged offsets are committed automatically on revocation.
+     * When group management is used, revoke listeners are invoked before every rebalance
+     * operation. With manual partition assignment using {@link MutableReceiverOptions#assignment()},
+     * revoke listeners are invoked once when the receive Flux is terminated.
+     * @return options instance with new partition revocation listener
+     */
+    @Override
+    public ReceiverOptions<K, V> addRevokeListener(Consumer<Collection<ReceiverPartition>> onRevoke) {
+        revokeListeners.add(Objects.requireNonNull(onRevoke));
+        return this;
+    }
+
+    /**
+     * Removes all partition assignment listeners.
+     * @return options instance without any partition assignment listeners
+     */
+    @Override
+    public ReceiverOptions<K, V> clearAssignListeners() {
+        assignListeners.clear();
+        return this;
+    }
+
+    /**
+     * Removes all partition revocation listeners.
+     * @return options instance without any partition revocation listeners
+     */
+    @Override
+    public ReceiverOptions<K, V> clearRevokeListeners() {
+        revokeListeners.clear();
+        return this;
+    }
+
+    /**
+     * Returns list of configured partition assignment listeners.
+     * @return list of assignment listeners
+     */
+    @Override
+    public List<Consumer<Collection<ReceiverPartition>>> assignListeners() {
+        return assignListeners;
+    }
+
+    /**
+     * Returns list of configured partition revocation listeners.
+     * @return list of revocation listeners
+     */
+    @Override
+    public List<Consumer<Collection<ReceiverPartition>>> revokeListeners() {
+        return revokeListeners;
+    }
+
+    /**
+     * Sets subscription using group management to the specified collection of topics.
+     * This subscription is enabled when the receive Flux of a {@link KafkaReceiver} using this
+     * options instance is subscribed to. Any existing subscriptions or assignments on this
+     * option are deleted.
+     * @return options instance with new subscription
+     */
+    @Override
+    public ReceiverOptions<K, V> subscription(Collection<String> topics) {
+        subscribeTopics = Objects.requireNonNull(topics);
+        subscribePattern = null;
+        assignTopicPartitions = null;
+        return this;
+    }
+
+    /**
+     * Sets subscription using group management to the specified pattern.
+     * This subscription is enabled when the receive Flux of a {@link KafkaReceiver} using this
+     * options instance is subscribed to. Any existing subscriptions or assignments on this
+     * option are deleted. Topics are dynamically assigned or removed when topics
+     * matching the pattern are created or deleted.
+     * @return options instance with new subscription
+     */
+    @Override
+    public ReceiverOptions<K, V> subscription(Pattern pattern) {
+        subscribeTopics = null;
+        subscribePattern = Objects.requireNonNull(pattern);
+        assignTopicPartitions = null;
+        return this;
+    }
+
+    /**
+     * Sets subscription using manual assignment to the specified partitions.
+     * This assignment is enabled when the receive Flux of a {@link KafkaReceiver} using this
+     * options instance is subscribed to. Any existing subscriptions or assignments on this
+     * option are deleted.
+     * @return options instance with new partition assignment
+     */
+    @Override
+    public ReceiverOptions<K, V> assignment(Collection<TopicPartition> partitions) {
+        subscribeTopics = null;
+        subscribePattern = null;
+        assignTopicPartitions = Objects.requireNonNull(partitions);
+        return this;
+    }
+
+    /**
+     * Returns the collection of partitions to be assigned if this instance is
+     * configured for manual partition assignment.
+     *
+     * @return partitions to be assigned
+     */
+    @Override
+    public Collection<TopicPartition> assignment() {
+        return assignTopicPartitions;
+    }
+
+    /**
+     * Returns the collection of Topics to be subscribed
+     *
+     * @return partitions to be assigned
+     */
+    @Override
+    public Collection<String> subscriptionTopics() {
+        return subscribeTopics;
+    }
+
+    /**
+     * Returns the Pattern by which the topic should be selected
+     * @return pattern of topics selection
+     */
+    @Override
+    public Pattern subscriptionPattern() {
+        return subscribePattern;
+    }
+
+    /**
+     * Returns the configured Kafka consumer group id.
+     * @return group id
+     */
+    @Override
+    public String groupId() {
+        return (String) consumerProperty(ConsumerConfig.GROUP_ID_CONFIG);
+    }
+
+    /**
+     * Returns the configured heartbeat interval for Kafka consumer.
+     * @return heartbeat interval duration
+     */
+    @Override
+    public Duration heartbeatInterval() {
+        long defaultValue = 3000; // Kafka default
+        long heartbeatIntervalMs = getLongOption(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, defaultValue);
+        return Duration.ofMillis(heartbeatIntervalMs);
+    }
+
+    /**
+     * Returns the configured commit interval for automatic commits of acknowledged records.
+     * @return commit interval duration
+     */
+    @Override
+    public Duration commitInterval() {
+        return commitInterval;
+    }
+
+    /**
+     * Configures commit interval for automatic commits. At least one commit operation is
+     * attempted within this interval if records are consumed and acknowledged.
+     * <p>
+     * If <code>commitInterval</code> is zero, periodic commits based on time intervals
+     * are disabled. If commit batch size is configured, offsets are committed when the number
+     * of acknowledged offsets reaches the batch size. If commit batch size is also zero, it
+     * is the responsibility of the application to explicitly commit records using
+     * {@link ReceiverOffset#commit()} if required.
+     * <p>
+     * If commit interval and commit batch size are configured, a commit operation is scheduled
+     * when either the interval or batch size is reached.
+     *
+     * @return options instance with new commit interval
+     */
+    @Override
+    public ReceiverOptions<K, V> commitInterval(Duration commitInterval) {
+        if (commitInterval == null || commitInterval.isNegative())
+            throw new IllegalArgumentException("Commit interval must be >= 0");
+        this.commitInterval = commitInterval;
+        return this;
+    }
+
+    /**
+     * Returns the configured commit batch size for automatic commits of acknowledged records.
+     * @return commit batch size
+     */
+    @Override
+    public int commitBatchSize() {
+        return commitBatchSize;
+    }
+
+    /**
+     * Configures commit batch size for automatic commits. At least one commit operation is
+     * attempted  when the number of acknowledged uncommitted offsets reaches this batch size.
+     * <p>
+     * If <code>commitBatchSize</code> is 0, commits are only performed based on commit
+     * interval. If commit interval is null, no automatic commits are performed and it is the
+     * responsibility of the application to commit offsets explicitly using {@link ReceiverOffset#commit()}
+     * if required.
+     * <p>
+     * If commit batch size and commit interval are configured, a commit operation is scheduled
+     * when either the batch size or interval is reached.
+     * @return options instance with new commit batch size
+     */
+    @Override
+    public ReceiverOptions<K, V> commitBatchSize(int commitBatchSize) {
+        if (commitBatchSize < 0)
+            throw new IllegalArgumentException("Commit batch size must be >= 0");
+        this.commitBatchSize = commitBatchSize;
+        return this;
+    }
+
+
+    /**
+     * Returns the maximum difference between the offset committed for at-most-once
+     * delivery and the offset of the last record dispatched. The maximum number
+     * of records that may be lost per-partition if the application fails is
+     * <code>commitAheadSize + 1</code>
+     * @return commit ahead size for at-most-once delivery
+     */
+    @Override
+    public int atmostOnceCommitAheadSize() {
+        return atmostOnceCommitAheadSize;
+    }
+
+    /**
+     * Configures commit ahead size per partition for at-most-once delivery. Before dispatching
+     * each record, an offset ahead by this size may be committed. The maximum number
+     * of records that may be lost if the application fails is <code>commitAheadSize + 1</code>.
+     * A high commit ahead size reduces the cost of commits in at-most-once delivery by
+     * reducing the number of commits and avoiding blocking before dispatch if the offset
+     * corresponding to the record was already committed.
+     * <p>
+     * If <code>commitAheadSize</code> is zero (default), offsets are committed synchronously before
+     * each record is dispatched for {@link KafkaReceiver#receiveAtmostOnce()}. Otherwise, commits are
+     * performed ahead of dispatch and record dispatch is blocked only if commits haven't completed.
+     * @return options instance with new commit ahead size
+     */
+    @Override
+    public ReceiverOptions<K, V> atmostOnceCommitAheadSize(int commitAheadSize) {
+        if (commitAheadSize < 0)
+            throw new IllegalArgumentException("Commit ahead size must be >= 0");
+
+        this.atmostOnceCommitAheadSize = commitAheadSize;
+        return this;
+    }
+
+    /**
+     * Returns the maximum number of consecutive non-fatal commit failures that are tolerated.
+     * For manual commits, failure in commit after the configured number of attempts fails
+     * the commit operation. For auto commits, the receive Flux is terminated.
+     * @return maximum number of commit attempts
+     */
+    @Override
+    public int maxCommitAttempts() {
+        return maxCommitAttempts;
+    }
+
+    /**
+     * Configures the maximum number of consecutive non-fatal {@link RetriableCommitFailedException}
+     * commit failures that are tolerated. For manual commits, failure in commit after the configured
+     * number of attempts fails the commit operation. For auto commits, the receive Flux is terminated
+     * if the commit does not succeed after these attempts.
+     *
+     * @return options instance with updated number of commit attempts
+     */
+    @Override
+    public ReceiverOptions<K, V> maxCommitAttempts(int maxAttempts) {
+        if (maxAttempts < 0)
+            throw new IllegalArgumentException("the number of attempts must be >= 0");
+
+        this.maxCommitAttempts = maxAttempts;
+        return this;
+    }
+
+    /**
+     * Returns the Supplier for a Scheduler that Records will be published on
+     * @return Scheduler Supplier to use for publishing
+     */
+    @Override
+    public Supplier<Scheduler> schedulerSupplier() {
+        return schedulerSupplier;
+    }
+
+    /**
+     * Configures the Supplier for a Scheduler on which Records will be published
+     * @return options instance with updated publishing Scheduler Supplier
+     */
+    @Override
+    public ReceiverOptions<K, V> schedulerSupplier(Supplier<Scheduler> schedulerSupplier) {
+        this.schedulerSupplier = Objects.requireNonNull(schedulerSupplier);
+        return this;
+    }
+
+    private long getLongOption(String optionName, long defaultValue) {
+        Objects.requireNonNull(optionName);
+
+        Object value = consumerProperty(optionName);
+        long optionValue = 0;
+        if (value != null) {
+            if (value instanceof Long)
+                optionValue = (Long) value;
+            else if (value instanceof String)
+                optionValue = Long.parseLong((String) value);
+            else
+                throw new ConfigException("Invalid value " + value);
+        } else
+            optionValue = defaultValue;
+        return optionValue;
+    }
+}

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerFactory.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerFactory.java
@@ -29,7 +29,7 @@ public class ConsumerFactory {
 
     public <K, V> Consumer<K, V> createConsumer(ReceiverOptions<K, V> config) {
         return new KafkaConsumer<>(config.consumerProperties(),
-                                   config.keyDeserializer().orElse(null),
-                                   config.valueDeserializer().orElse(null));
+                                   config.keyDeserializer(),
+                                   config.valueDeserializer());
     }
 }

--- a/src/main/java/reactor/kafka/sender/ImmutableSenderOptions.java
+++ b/src/main/java/reactor/kafka/sender/ImmutableSenderOptions.java
@@ -26,7 +26,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serializer;
 import reactor.core.scheduler.Scheduler;
 
-public class ImmutableSenderOptions<K, V> implements SenderOptions<K, V> {
+class ImmutableSenderOptions<K, V> implements SenderOptions<K, V> {
 
     private final Map<String, Object> properties;
     private final Serializer<K>       keySerializer;

--- a/src/main/java/reactor/kafka/sender/ImmutableSenderOptions.java
+++ b/src/main/java/reactor/kafka/sender/ImmutableSenderOptions.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.kafka.sender;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.Serializer;
+import reactor.core.scheduler.Scheduler;
+
+public class ImmutableSenderOptions<K, V> implements SenderOptions<K, V> {
+
+    private final Map<String, Object> properties;
+    private final Serializer<K>       keySerializer;
+    private final Serializer<V>       valueSerializer;
+    private final Duration            closeTimeout;
+    private final Scheduler           scheduler;
+    private final int                 maxInFlight;
+    private final boolean             stopOnError;
+
+    ImmutableSenderOptions(SenderOptions<K, V> options) {
+        this(
+            new HashMap<>(options.producerProperties()),
+            options.keySerializer(),
+            options.valueSerializer(),
+            options.closeTimeout(),
+            options.scheduler(),
+            options.maxInFlight(),
+            options.stopOnError()
+        );
+    }
+
+    ImmutableSenderOptions(
+            Map<String, Object> properties,
+            Serializer<K> serializer,
+            Serializer<V> valueSerializer,
+            Duration timeout,
+            Scheduler scheduler,
+            int flight,
+            boolean error
+    ) {
+        this.properties = properties;
+        keySerializer = serializer;
+        this.valueSerializer = valueSerializer;
+        closeTimeout = timeout;
+        this.scheduler = scheduler;
+        maxInFlight = flight;
+        stopOnError = error;
+    }
+
+    /**
+     * Returns the configuration properties for the underlying Kafka {@link Producer}.
+     * @return configuration options for Kafka producer
+     */
+    @Override
+    public Map<String, Object> producerProperties() {
+        return new HashMap<>(properties);
+    }
+
+    /**
+     * Returns the Kafka {@link Producer} configuration property value for the specified option name.
+     * @return Kafka producer configuration option value
+     */
+    @Override
+    public Object producerProperty(String name) {
+        Objects.requireNonNull(name);
+
+        return properties.get(name);
+    }
+
+    /**
+     * Sets Kafka {@link Producer} configuration property to the specified value.
+     * @return sender options with updated Kafka producer option
+     */
+    @Override
+    public SenderOptions<K, V> producerProperty(String name, Object value) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(value);
+
+        HashMap<String, Object> properties = new HashMap<>(this.properties);
+        properties.put(name, value);
+
+        return new ImmutableSenderOptions<>(
+                properties,
+                keySerializer,
+                valueSerializer,
+                closeTimeout,
+                scheduler,
+                maxInFlight,
+                stopOnError
+        );
+    }
+
+    /**
+     *
+     * Returns optionally a serializer witch is used by {@link KafkaProducer} for key serialization.
+     * @return configured key serializer instant
+     */
+    @Override
+    public Serializer<K> keySerializer() {
+        return keySerializer;
+    }
+
+    /**
+     * Set a concrete serializer instant to be used by the {@link KafkaProducer} for keys. Overrides any setting of the
+     * {@link ProducerConfig#KEY_SERIALIZER_CLASS_CONFIG} property.
+     * @param keySerializer key serializer to use in the consumer
+     * @return options instance with new key serializer
+     */
+    @Override
+    public SenderOptions<K, V> withKeySerializer(Serializer<K> keySerializer) {
+        return new ImmutableSenderOptions<>(
+                properties,
+                Objects.requireNonNull(keySerializer),
+                valueSerializer,
+                closeTimeout,
+                scheduler,
+                maxInFlight,
+                stopOnError
+        );
+    }
+
+    /**
+     *
+     * Returns optionally a serializer witch is used by {@link KafkaProducer} for value serialization.
+     * @return configured value serializer instant
+     */
+    @Override
+    public Serializer<V> valueSerializer() {
+        return valueSerializer;
+    }
+
+    /**
+     * Set a concrete serializer instant to be used by the {@link KafkaProducer} for values. Overrides any setting of the
+     * {@link ProducerConfig#VALUE_SERIALIZER_CLASS_CONFIG} property.
+     * @param valueSerializer value serializer to use in the consumer
+     * @return options instance with new value serializer
+     */
+    @Override
+    public SenderOptions<K, V> withValueSerializer(Serializer<V> valueSerializer) {
+        return new ImmutableSenderOptions<>(
+                properties,
+                keySerializer,
+                Objects.requireNonNull(valueSerializer),
+                closeTimeout,
+                scheduler,
+                maxInFlight,
+                stopOnError
+        );
+    }
+
+    /**
+     * Returns the scheduler used for publishing send results.
+     * @return response scheduler
+     */
+    @Override
+    public Scheduler scheduler() {
+        return scheduler;
+    }
+
+    /**
+     * Sets the scheduler used for publishing send results.
+     * @return sender options with updated response scheduler
+     */
+    @Override
+    public SenderOptions<K, V> scheduler(Scheduler scheduler) {
+        return new ImmutableSenderOptions<>(
+                properties,
+                keySerializer,
+                valueSerializer,
+                closeTimeout,
+                Objects.requireNonNull(scheduler),
+                maxInFlight,
+                stopOnError
+        );
+    }
+
+    /**
+     * Returns the maximum number of in-flight records that are fetched
+     * from the outbound record publisher while acknowledgements are pending.
+     * @return maximum number of in-flight records
+     */
+    @Override
+    public int maxInFlight() {
+        return maxInFlight;
+    }
+
+    /**
+     * Configures the maximum number of in-flight records that are fetched
+     * from the outbound record publisher while acknowledgements are pending.
+     * This limit must be configured along with {@link ProducerConfig#BUFFER_MEMORY_CONFIG}
+     * to control memory usage and to avoid blocking the reactive pipeline.
+     * @return sender options with new in-flight limit
+     */
+    @Override
+    public SenderOptions<K, V> maxInFlight(int maxInFlight) {
+        return new ImmutableSenderOptions<>(
+                properties,
+                keySerializer,
+                valueSerializer,
+                closeTimeout,
+                scheduler,
+                maxInFlight,
+                stopOnError
+        );
+    }
+
+    /**
+     * Returns stopOnError configuration which indicates if a send operation
+     * should be terminated when an error is encountered. If set to false, send
+     * is attempted for all records in a sequence even if send of one of the records fails
+     * with a non-fatal exception.
+     * @return boolean indicating if send sequences should fail on first error
+     */
+    @Override
+    public boolean stopOnError() {
+        return stopOnError;
+    }
+
+    /**
+     * Configures error handling behaviour for {@link KafkaSender#send(org.reactivestreams.Publisher)}.
+     * If set to true, send fails when an error is encountered and only records
+     * that are already in transit may be delivered after the first error. If set to false,
+     * an attempt is made to send each record to Kafka, even if one or more records cannot
+     * be delivered after the configured number of retries due to a non-fatal exception.
+     * This flag should be set along with {@link ProducerConfig#RETRIES_CONFIG} and
+     * {@link ProducerConfig#ACKS_CONFIG} to configure the required quality-of-service.
+     * By default, stopOnError is true.
+     * @param stopOnError true to stop each send sequence on first failure
+     * @return sender options with the new stopOnError flag.
+     */
+    @Override
+    public SenderOptions<K, V> stopOnError(boolean stopOnError) {
+        return new ImmutableSenderOptions<>(
+                properties,
+                keySerializer,
+                valueSerializer,
+                closeTimeout,
+                scheduler,
+                maxInFlight,
+                stopOnError
+        );
+    }
+
+    /**
+     * Returns the timeout for graceful shutdown of this sender.
+     * @return close timeout duration
+     */
+    @Override
+    public Duration closeTimeout() {
+        return closeTimeout;
+    }
+
+    /**
+     * Configures the timeout for graceful shutdown of this sender.
+     * @return sender options with updated close timeout
+     */
+    @Override
+    public SenderOptions<K, V> closeTimeout(Duration timeout) {
+        return new ImmutableSenderOptions<>(
+                properties,
+                keySerializer,
+                valueSerializer,
+                closeTimeout,
+                scheduler,
+                maxInFlight,
+                stopOnError
+        );
+    }
+}

--- a/src/main/java/reactor/kafka/sender/MutableSenderOptions.java
+++ b/src/main/java/reactor/kafka/sender/MutableSenderOptions.java
@@ -1,80 +1,119 @@
+/*
+ * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package reactor.kafka.sender;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
-
-import javax.naming.AuthenticationException;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.serialization.Serializer;
 import reactor.core.scheduler.Scheduler;
-import reactor.util.annotation.NonNull;
-import reactor.util.annotation.Nullable;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.concurrent.Queues;
 
-public interface SenderOptions<K, V> {
+/**
+ * Configuration properties for reactive Kafka {@link KafkaSender} and its underlying Kafka
+ * @deprecated in favor of {@link ImmutableSenderOptions}
+ * {@link Producer}.
+ */
+@Deprecated
+public class MutableSenderOptions<K, V> implements SenderOptions<K, V> {
 
-    /**
-     * Creates a sender options instance with default properties.
-     * @return new instance of sender options
-     */
-    @NonNull
-    static <K, V> SenderOptions<K, V> create() {
-        return new MutableSenderOptions<>();
+    private final Map<String, Object> properties;
+
+    private Serializer<K> keySerializer;
+    private Serializer<V> valueSerializer;
+    private Duration closeTimeout;
+    private Scheduler scheduler;
+    private int maxInFlight;
+    private boolean stopOnError;
+
+    MutableSenderOptions() {
+        this(new HashMap<>());
     }
 
-    /**
-     * Creates a sender options instance with the specified config overrides for the underlying
-     * Kafka {@link Producer}.
-     * @return new instance of sender options
-     */
-    @NonNull
-    static <K, V> SenderOptions<K, V> create(@NonNull Map<String, Object> configProperties) {
-        return new MutableSenderOptions<>(configProperties);
+    MutableSenderOptions(Properties properties) {
+        this(
+            properties
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                    e -> e.getKey().toString(),
+                    Map.Entry::getValue
+                ))
+        );
     }
 
-    /**
-     * Creates a sender options instance with the specified config overrides for the underlying
-     * Kafka {@link Producer}.
-     * @return new instance of sender options
-     */
-    @NonNull
-    static <K, V> SenderOptions<K, V> create(@NonNull Properties configProperties) {
-        return new MutableSenderOptions<>(configProperties);
+    MutableSenderOptions(Map<String, Object> properties) {
+        this.properties = new HashMap<>(properties);
+
+        closeTimeout = Duration.ofMillis(Long.MAX_VALUE);
+        scheduler = Schedulers.single();
+        maxInFlight = Queues.SMALL_BUFFER_SIZE;
+        stopOnError = true;
     }
 
     /**
      * Returns the configuration properties for the underlying Kafka {@link Producer}.
      * @return configuration options for Kafka producer
      */
-    @NonNull
-    Map<String, Object> producerProperties();
+    @Override
+    public Map<String, Object> producerProperties() {
+        return properties;
+    }
 
     /**
      * Returns the Kafka {@link Producer} configuration property value for the specified option name.
      * @return Kafka producer configuration option value
      */
-    @Nullable
-    Object producerProperty(@NonNull String name);
+    @Override
+    public Object producerProperty(String name) {
+        Objects.requireNonNull(name);
+
+        return properties.get(name);
+    }
 
     /**
      * Sets Kafka {@link Producer} configuration property to the specified value.
      * @return sender options with updated Kafka producer option
      */
-    @NonNull
-    SenderOptions<K, V> producerProperty(@NonNull String name, @NonNull Object value);
+    @Override
+    public SenderOptions<K, V> producerProperty(String name, Object value) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(value);
+
+        properties.put(name, value);
+        return this;
+    }
 
     /**
      *
      * Returns optionally a serializer witch is used by {@link KafkaProducer} for key serialization.
      * @return configured key serializer instant
      */
-    @Nullable
-    Serializer<K> keySerializer();
+    @Override
+    public Serializer<K> keySerializer() {
+        return keySerializer;
+    }
 
     /**
      * Set a concrete serializer instant to be used by the {@link KafkaProducer} for keys. Overrides any setting of the
@@ -82,16 +121,21 @@ public interface SenderOptions<K, V> {
      * @param keySerializer key serializer to use in the consumer
      * @return options instance with new key serializer
      */
-    @NonNull
-    SenderOptions<K, V> withKeySerializer(@NonNull Serializer<K> keySerializer);
+    @Override
+    public  SenderOptions<K, V> withKeySerializer(Serializer<K> keySerializer) {
+        this.keySerializer = Objects.requireNonNull(keySerializer);
+        return this;
+    }
 
     /**
      *
      * Returns optionally a serializer witch is used by {@link KafkaProducer} for value serialization.
      * @return configured value serializer instant
      */
-    @Nullable
-    Serializer<V> valueSerializer();
+    @Override
+    public Serializer<V> valueSerializer() {
+        return valueSerializer;
+    }
 
     /**
      * Set a concrete serializer instant to be used by the {@link KafkaProducer} for values. Overrides any setting of the
@@ -99,30 +143,40 @@ public interface SenderOptions<K, V> {
      * @param valueSerializer value serializer to use in the consumer
      * @return options instance with new value serializer
      */
-    @NonNull
-    SenderOptions<K, V> withValueSerializer(@NonNull Serializer<V> valueSerializer);
+    @Override
+    public  SenderOptions<K, V> withValueSerializer(Serializer<V> valueSerializer) {
+        this.valueSerializer = Objects.requireNonNull(valueSerializer);
+        return this;
+    }
 
     /**
      * Returns the scheduler used for publishing send results.
      * @return response scheduler
      */
-    @NonNull
-    Scheduler scheduler();
+    @Override
+    public Scheduler scheduler() {
+        return scheduler;
+    }
 
     /**
      * Sets the scheduler used for publishing send results.
      * @return sender options with updated response scheduler
      */
-    @NonNull
-    SenderOptions<K, V> scheduler(@NonNull Scheduler scheduler);
+    @Override
+    public SenderOptions<K, V> scheduler(Scheduler scheduler) {
+        this.scheduler = Objects.requireNonNull(scheduler);
+        return this;
+    }
 
     /**
      * Returns the maximum number of in-flight records that are fetched
      * from the outbound record publisher while acknowledgements are pending.
      * @return maximum number of in-flight records
      */
-    @NonNull
-    int maxInFlight();
+    @Override
+    public int maxInFlight() {
+        return maxInFlight;
+    }
 
     /**
      * Configures the maximum number of in-flight records that are fetched
@@ -131,8 +185,11 @@ public interface SenderOptions<K, V> {
      * to control memory usage and to avoid blocking the reactive pipeline.
      * @return sender options with new in-flight limit
      */
-    @NonNull
-    SenderOptions<K, V> maxInFlight(@NonNull int maxInFlight);
+    @Override
+    public SenderOptions<K, V> maxInFlight(int maxInFlight) {
+        this.maxInFlight = maxInFlight;
+        return this;
+    }
 
     /**
      * Returns stopOnError configuration which indicates if a send operation
@@ -141,8 +198,10 @@ public interface SenderOptions<K, V> {
      * with a non-fatal exception.
      * @return boolean indicating if send sequences should fail on first error
      */
-    @NonNull
-    boolean stopOnError();
+    @Override
+    public boolean stopOnError() {
+        return stopOnError;
+    }
 
     /**
      * Configures error handling behaviour for {@link KafkaSender#send(org.reactivestreams.Publisher)}.
@@ -156,65 +215,28 @@ public interface SenderOptions<K, V> {
      * @param stopOnError true to stop each send sequence on first failure
      * @return sender options with the new stopOnError flag.
      */
-    @NonNull
-    SenderOptions<K, V> stopOnError(@NonNull boolean stopOnError);
+    @Override
+    public SenderOptions<K, V> stopOnError(boolean stopOnError) {
+        this.stopOnError = stopOnError;
+        return this;
+    }
 
     /**
      * Returns the timeout for graceful shutdown of this sender.
      * @return close timeout duration
      */
-    @NonNull
-    Duration closeTimeout();
+    @Override
+    public Duration closeTimeout() {
+        return closeTimeout;
+    }
 
     /**
      * Configures the timeout for graceful shutdown of this sender.
      * @return sender options with updated close timeout
      */
-    @NonNull
-    SenderOptions<K, V> closeTimeout(@NonNull Duration timeout);
-
-    /**
-     * Senders created from this options will be transactional if a transactional id is
-     * configured using {@link ProducerConfig#TRANSACTIONAL_ID_CONFIG}. If transactional,
-     * {@link KafkaProducer#initTransactions()} is invoked on the producer to initialize
-     * transactions before any operations are performed on the sender. If scheduler is overridden
-     * using {@link #scheduler(Scheduler)}, the configured scheduler
-     * must be single-threaded. Otherwise, the behaviour is undefined and may result in unexpected
-     * exceptions.
-     */
-    @NonNull
-    default boolean isTransactional() {
-        String transactionalId = transactionalId();
-        return transactionalId != null && !transactionalId.isEmpty();
-    }
-
-    /**
-     * Returns the configured transactional id
-     * @return transactional id
-     */
-    @Nullable
-    default String transactionalId() {
-        return (String) producerProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
-    }
-
-    @NonNull
-    default boolean fatalException(@NonNull Throwable t) {
-        return t instanceof AuthenticationException || t instanceof ProducerFencedException;
-    }
-
-    /**
-     * Returns a new immutable instance with the configuration properties of this instance.
-     * @deprecated starting from 3.x version will be immutable by default
-     * @return new immutable instance of sender options
-     */
-    @NonNull
-    @Deprecated
-    default SenderOptions<K, V> toImmutable() {
-        if (isTransactional()) {
-            if (!stopOnError())
-                throw new ConfigException("Transactional senders must be created with stopOnError=true");
-        }
-
-        return new ImmutableSenderOptions<>(this);
+    @Override
+    public SenderOptions<K, V> closeTimeout(Duration timeout) {
+        this.closeTimeout = timeout;
+        return this;
     }
 }

--- a/src/main/java/reactor/kafka/sender/MutableSenderOptions.java
+++ b/src/main/java/reactor/kafka/sender/MutableSenderOptions.java
@@ -36,7 +36,7 @@ import reactor.util.concurrent.Queues;
  * {@link Producer}.
  */
 @Deprecated
-public class MutableSenderOptions<K, V> implements SenderOptions<K, V> {
+class MutableSenderOptions<K, V> implements SenderOptions<K, V> {
 
     private final Map<String, Object> properties;
 

--- a/src/main/java/reactor/kafka/sender/internals/ProducerFactory.java
+++ b/src/main/java/reactor/kafka/sender/internals/ProducerFactory.java
@@ -29,7 +29,7 @@ public class ProducerFactory {
 
     public <K, V> Producer<K, V> createProducer(SenderOptions<K, V> senderOptions) {
         return new KafkaProducer<>(senderOptions.producerProperties(),
-                                   senderOptions.keySerializer().orElse(null),
-                                   senderOptions.valueSerializer().orElse(null));
+                                   senderOptions.keySerializer(),
+                                   senderOptions.valueSerializer());
     }
 }

--- a/src/test/java/reactor/kafka/AbstractKafkaTest.java
+++ b/src/test/java/reactor/kafka/AbstractKafkaTest.java
@@ -129,7 +129,7 @@ public class AbstractKafkaTest {
     public ProducerRecord<Integer, String> createProducerRecord(int index, boolean expectSuccess) {
         int partition = index % partitions;
         if (expectSuccess) expectedMessages.get(partition).add(index);
-        return new ProducerRecord<Integer, String>(topic, partition, index, "Message " + index);
+        return new ProducerRecord<>(topic, partition, index, "Message " + index);
     }
 
     public Flux<ProducerRecord<Integer, String>> createProducerRecords(int startIndex, int count, boolean expectSuccess) {
@@ -155,7 +155,7 @@ public class AbstractKafkaTest {
 
     public void checkConsumedMessages(int partition, int receiveStartIndex, int receiveEndIndex) {
         // Remove the messages still in the send list which should not be consumed
-        List<Integer> expected = new ArrayList<Integer>(expectedMessages.get(partition));
+        List<Integer> expected = new ArrayList<>(expectedMessages.get(partition));
         Iterator<Integer> it = expected.iterator();
         while (it.hasNext()) {
             int index = it.next();

--- a/src/test/java/reactor/kafka/cluster/EmbeddedKafkaCluster.java
+++ b/src/test/java/reactor/kafka/cluster/EmbeddedKafkaCluster.java
@@ -73,7 +73,8 @@ public class EmbeddedKafkaCluster extends ExternalResource {
                 scala.Option.apply(null),
                 true, false, 0, false, 0, false, 0,
                 scala.Option.apply(null),
-                1);
+                1,
+                false);
             props.put(KafkaConfig.MinInSyncReplicasProp(), "1");
             props.put(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1");
             props.put(KafkaConfig.TransactionsTopicMinISRProp(), "1");

--- a/src/test/java/reactor/kafka/mock/MockConsumer.java
+++ b/src/test/java/reactor/kafka/mock/MockConsumer.java
@@ -15,6 +15,7 @@
  */
 package reactor.kafka.mock;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
@@ -201,7 +202,7 @@ public class MockConsumer extends org.apache.kafka.clients.consumer.MockConsumer
     }
 
     @Override
-    public ConsumerRecords<Integer, String> poll(long timeout) {
+    public ConsumerRecords<Integer, String> poll(Duration timeout) {
         acquire();
         try {
             pollCount.incrementAndGet();
@@ -209,7 +210,7 @@ public class MockConsumer extends org.apache.kafka.clients.consumer.MockConsumer
             if (assignmentPending) {
                 doAssign();
                 assignmentPending = false;
-                return new ConsumerRecords<Integer, String>(records);
+                return new ConsumerRecords<>(records);
             }
             runCompletedCallbacks();
             try {

--- a/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
@@ -1252,7 +1252,7 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
             .map(i -> createProducerRecord(i, true))
             .concatMap(record -> kafkaSender.createOutbound().send(Mono.just(record)).then()
                                             .doOnSuccess(metadata -> latch.countDown())
-                                            .retry(100))
+                                            .retryBackoff(100, Duration.ofMillis(100)))
             .subscribe();
         assertTrue("Messages not sent ", latch.await(receiveTimeoutMillis, TimeUnit.MILLISECONDS));
     }

--- a/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
@@ -47,7 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
@@ -84,7 +83,6 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
 
     @Before
     public void setUp() throws Exception {
-        Hooks.onOperatorDebug();
         super.setUp();
         kafkaSender = KafkaSender.create(senderOptions);
         kafkaSenders = new HashSet<>();

--- a/src/test/java/reactor/kafka/receiver/ReceiverOptionsTest.java
+++ b/src/test/java/reactor/kafka/receiver/ReceiverOptionsTest.java
@@ -1,15 +1,30 @@
+/*
+ * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package reactor.kafka.receiver;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 public class ReceiverOptionsTest {
 
@@ -30,10 +45,10 @@ public class ReceiverOptionsTest {
     public void deserializersAreMaintainedWhenToImmutableIsCalled() {
         ReceiverOptions<String, String> immutableOptions = receiverOptions.toImmutable();
 
-        assertTrue(immutableOptions.valueDeserializer().isPresent());
-        assertTrue(immutableOptions.keyDeserializer().isPresent());
-        assertEquals(receiverOptions.valueDeserializer().get(), immutableOptions.valueDeserializer().get());
-        assertEquals(receiverOptions.keyDeserializer().get(), immutableOptions.keyDeserializer().get());
+        assertNotNull(immutableOptions.valueDeserializer());
+        assertNotNull(immutableOptions.keyDeserializer());
+        assertEquals(receiverOptions.valueDeserializer(), immutableOptions.valueDeserializer());
+        assertEquals(receiverOptions.keyDeserializer(), immutableOptions.keyDeserializer());
     }
 
     static class TestDeserializer implements Deserializer<String> {

--- a/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
@@ -48,7 +48,6 @@ import java.util.regex.Pattern;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -1272,11 +1271,7 @@ public class MockReceiverTest {
             public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
             }
         };
-        OffsetCommitCallback commitListener = new OffsetCommitCallback() {
-            @Override
-            public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
-            }
-        };
+        OffsetCommitCallback commitListener = (offsets, exception) -> { };
         testDisallowedConsumerMethod(c -> c.poll(0));
         testDisallowedConsumerMethod(c -> c.close());
         testDisallowedConsumerMethod(c -> c.assign(Collections.singleton(new TopicPartition(topic, 0))));


### PR DESCRIPTION
* Clean-up immutability for Sender and Receiver options
* migrate to kafka 2.0.0
* update gradle to 4.10
* removed redundant KafkaScheduler#fromWorker (replaced to Schedulers.single())
* update to Reactor 3.2.0.RELEASE

* update docs to upcoming release