### PR TITLE
pluggable producer/consumer factory

### DIFF
--- a/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
@@ -46,8 +46,22 @@ public interface KafkaReceiver<K, V> {
      *        must be set on the options instance prior to creating this receiver.
      * @return new receiver instance
      */
-    public static <K, V> KafkaReceiver<K, V> create(ReceiverOptions<K, V> options) {
+    static <K, V> KafkaReceiver<K, V> create(ReceiverOptions<K, V> options) {
         return new DefaultKafkaReceiver<>(ConsumerFactory.INSTANCE, options);
+    }
+
+    /**
+     * Creates a reactive Kafka receiver with the specified configuration options.
+     *
+     * @param factory A custom consumer factory other than the default.
+     * @param options Configuration options of this receiver. Changes made to the options
+     *        after the receiver is created will not be used by the receiver.
+     *        A subscription using group management or a manual assignment of topic partitions
+     *        must be set on the options instance prior to creating this receiver.
+     * @return new receiver instance
+     */
+    static <K, V> KafkaReceiver<K, V> create(ConsumerFactory factory, ReceiverOptions<K, V> options) {
+        return new DefaultKafkaReceiver<>(factory, options);
     }
 
     /**

--- a/src/main/java/reactor/kafka/sender/KafkaSender.java
+++ b/src/main/java/reactor/kafka/sender/KafkaSender.java
@@ -44,8 +44,20 @@ public interface KafkaSender<K, V> {
      *        after the sender is created will not be used by the sender.
      * @return new instance of Kafka sender
      */
-    public static <K, V> KafkaSender<K, V> create(SenderOptions<K, V> options) {
+    static <K, V> KafkaSender<K, V> create(SenderOptions<K, V> options) {
         return new DefaultKafkaSender<>(ProducerFactory.INSTANCE, options);
+    }
+
+    /**
+     * Creates a Kafka sender that appends records to Kafka topic partitions.
+     *
+     * @param factory A custom producer factory other than the default.
+     * @param options Configuration options of this sender. Changes made to the options
+     *        after the sender is created will not be used by the sender.
+     * @return new instance of Kafka sender
+     */
+    static <K, V> KafkaSender<K, V> create(ProducerFactory factory, SenderOptions<K, V> options) {
+        return new DefaultKafkaSender<>(factory, options);
     }
 
     /**


### PR DESCRIPTION
Current implementation only creates default KafkaConsumer/KafkaProducer, thus making tracing such as zipkin impossible. Provide capability to allow user to provide a custom ConsumerFactory/ProducerFactory, thus allowing the creation of custom Consumer/Producer