### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@
 
 buildscript {
   repositories {
-    maven { url "http://repo.spring.io/plugins-release" }
+    maven { url "https://repo.spring.io/plugins-release" }
   }
   dependencies {
     classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16',
@@ -45,10 +45,10 @@ ext {
   zkVersion = "3.4.13"
   powermockVersion = '1.7.4'
 
-  javadocLinks = ["http://docs.oracle.com/javase/8/docs/api/",
+  javadocLinks = ["https://docs.oracle.com/javase/8/docs/api/",
                   "https://kafka.apache.org/10/javadoc/",
-                  "http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/",
-                  "http://projectreactor.io/docs/core/release/api/"] as String[]
+                  "https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/",
+                  "https://projectreactor.io/docs/core/release/api/"] as String[]
 
 }
 
@@ -71,8 +71,8 @@ configure(allprojects) { project ->
   group = 'io.projectreactor.kafka'
 
   repositories {
-    maven { url 'http://repo.spring.io/libs-release' }
-    maven { url 'http://repo.spring.io/libs-snapshot' }
+    maven { url 'https://repo.spring.io/libs-release' }
+    maven { url 'https://repo.spring.io/libs-snapshot' }
     mavenCentral()
     jcenter()
   }

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -68,12 +68,12 @@ def customizePom(def pom, def gradleProject) {
             url = 'https://github.com/reactor/reactor-kafka'
             organization {
                 name = 'reactor'
-                url = 'http://github.com/reactor'
+                url = 'https://github.com/reactor'
             }
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.oracle.com/javase/8/docs/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/8/docs/api/ ([https](https://docs.oracle.com/javase/8/docs/api/) result 200).
* http://github.com/reactor with 1 occurrences migrated to:  
  https://github.com/reactor ([https](https://github.com/reactor) result 200).
* http://projectreactor.io/docs/core/release/api/ with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/api/ ([https](https://projectreactor.io/docs/core/release/api/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 3 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/ with 1 occurrences migrated to:  
  https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/ ([https](https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/) result 200).
* http://repo.spring.io/libs-release with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).
* http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/plugins-release with 1 occurrences migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).