### PR TITLE
URL Cleanup

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,5 +4,5 @@ Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
 Copyright 2016-2018 The Apache Software Foundation.
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Reactor Kafka
 [![Travis CI](https://img.shields.io/travis/reactor/reactor-kafka.svg)](https://travis-ci.org/reactor/reactor-kafka)
 [![Coverage](https://img.shields.io/codecov/c/github/reactor/reactor-kafka.svg)](https://travis-ci.org/reactor/reactor-kafka)
 
-You need to have [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) installed.
+You need to have [Java 8](https://www.oracle.com/technetwork/java/javase/downloads/index.html) installed.
 
 ### Building Reactor Kafka jars ###
     ./gradlew jar
@@ -39,8 +39,8 @@ See [reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleConsumer.ja
 With Gradle from repo.spring.io:
 ```groovy
     repositories {
-      //maven { url 'http://repo.spring.io/snapshot' }
-      maven { url 'http://repo.spring.io/milestone' }
+      //maven { url 'https://repo.spring.io/snapshot' }
+      maven { url 'https://repo.spring.io/milestone' }
       mavenCentral()
     }
 

--- a/src/api/stylesheet.css
+++ b/src/api/stylesheet.css
@@ -105,7 +105,7 @@ Document title and Copyright styles
     position: absolute;
     right: 2px;
     top: 10px;
-    background: url(http://projectreactor.io/assets/img/logo-2x.png) no-repeat 0 -30px;
+    background: url(https://projectreactor.io/assets/img/logo-2x.png) no-repeat 0 -30px;
     background-size: 189px 60px;
     height: 40px;
     width: 44px;

--- a/src/docs/asciidoc/getting-started.adoc
+++ b/src/docs/asciidoc/getting-started.adoc
@@ -5,14 +5,14 @@
 
 You need Java JRE installed (Java 8 or later).
 
-You need http://kafka.apache.org[Apache Kafka] installed (1.0.0 or later). Kafka can be downloaded
+You need https://kafka.apache.org[Apache Kafka] installed (1.0.0 or later). Kafka can be downloaded
 from https://kafka.apache.org/downloads.html. Note that the Apache Kafka client library used with
 Reactor Kafka should be 2.0.0 or later and the broker version should be 1.0.0 or higher.
 
 === Quick Start
 
 This quick start tutorial sets up a single node Zookeeper and Kafka and runs the sample reactive producer and
-consumer. Instructions to set up multi-broker clusters are available http://kafka.apache.org/documentation#quickstart_multibroker[here].
+consumer. Instructions to set up multi-broker clusters are available https://kafka.apache.org/documentation#quickstart_multibroker[here].
 
 ==== Start Kafka
 

--- a/src/docs/asciidoc/index.asciidoc
+++ b/src/docs/asciidoc/index.asciidoc
@@ -12,7 +12,7 @@ ifndef::host-github[:ext-relative: {outfilesuffix}]
 :hide-uri-scheme:
 
 :github-repo: reactor/reactor-kafka
-:github-code: http://github.com/{github-repo}
+:github-code: https://github.com/{github-repo}
 
 // ======================================================================================
 = Introduction

--- a/src/docs/asciidoc/motivation.adoc
+++ b/src/docs/asciidoc/motivation.adoc
@@ -42,7 +42,7 @@ the application is implemented in a functional style.
 
 ==== Kafka Connect API
 
-http://kafka.apache.org/documentation#connect[Kafka Connect] provides a simple interface to migrate messages
+https://kafka.apache.org/documentation#connect[Kafka Connect] provides a simple interface to migrate messages
 from an external data system (e.g. a database) to one or more Kafka topics. Using existing connectors,
 this migration can be performed without writing any new code.
 
@@ -56,7 +56,7 @@ use of threads and memory without the need for overflow handling in the applicat
 
 ==== Kafka Streams API
 
-http://kafka.apache.org/documentation#streams[Kafka Streams] provides lightweight APIs to build stream processing
+https://kafka.apache.org/documentation#streams[Kafka Streams] provides lightweight APIs to build stream processing
 applications that process data stored in Kafka using standard streaming concepts and transformation primitives.
 Using a simple threading model, the streams API avoids the need for back-pressure. This model works well in cases
 where transformations do not involve external interactions.

--- a/src/docs/asciidoc/resources.adoc
+++ b/src/docs/asciidoc/resources.adoc
@@ -15,9 +15,9 @@ Reactor Kafka is open source and the code and documentation are available at htt
 
 * https://github.com/reactor/reactor-kafka[Reactor Kafka on github]
 
-* http://kafka.apache.org/documentation.html[Apache Kafka]
+* https://kafka.apache.org/documentation.html[Apache Kafka]
 
-* http://projectreactor.io/[Project Reactor]
+* https://projectreactor.io/[Project Reactor]
 
 * https://github.com/reactor/reactor-core[Reactor Core]
 

--- a/src/docs/asciidoc/stylesheets/asciidoctor.css
+++ b/src/docs/asciidoc/stylesheets/asciidoctor.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/colony.css
+++ b/src/docs/asciidoc/stylesheets/colony.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/foundation-lime.css
+++ b/src/docs/asciidoc/stylesheets/foundation-lime.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/foundation-potion.css
+++ b/src/docs/asciidoc/stylesheets/foundation-potion.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/foundation.css
+++ b/src/docs/asciidoc/stylesheets/foundation.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/github.css
+++ b/src/docs/asciidoc/stylesheets/github.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/golo.css
+++ b/src/docs/asciidoc/stylesheets/golo.css
@@ -1,11 +1,11 @@
 @import url(https://fonts.googleapis.com/css?family=Montserrat:400,700);
-@import url(http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css);
 
 
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/iconic.css
+++ b/src/docs/asciidoc/stylesheets/iconic.css
@@ -1,9 +1,9 @@
-/* Inspired by the O'Reilly typography and the Atlas user manual | http://oreilly.com */
-@import url(http://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic);
+/* Inspired by the O'Reilly typography and the Atlas user manual | https://oreilly.com */
+@import url(https://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic);
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/maker.css
+++ b/src/docs/asciidoc/stylesheets/maker.css
@@ -1,8 +1,8 @@
-@import url(http://fonts.googleapis.com/css?family=Glegoo);
+@import url(https://fonts.googleapis.com/css?family=Glegoo);
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/readthedocs.css
+++ b/src/docs/asciidoc/stylesheets/readthedocs.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/rocket-panda.css
+++ b/src/docs/asciidoc/stylesheets/rocket-panda.css
@@ -1,8 +1,8 @@
-@import url(http://openshift.redhat.com/app/assets-20130701203230/overpass.css);
+@import url(https://openshift.redhat.com/app/assets-20130701203230/overpass.css);
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;

--- a/src/docs/asciidoc/stylesheets/rubygems.css
+++ b/src/docs/asciidoc/stylesheets/rubygems.css
@@ -1,7 +1,7 @@
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css);
 
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
     display: block;


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css with 12 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css ([https](https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.css) result 200).
* http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css with 1 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css ([https](https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/1.6.2/semantic.min.css) result 200).
* http://fonts.googleapis.com/css?family=Glegoo with 1 occurrences migrated to:  
  https://fonts.googleapis.com/css?family=Glegoo ([https](https://fonts.googleapis.com/css?family=Glegoo) result 200).
* http://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic with 1 occurrences migrated to:  
  https://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic ([https](https://fonts.googleapis.com/css?family=Lato:400,700,700italic,400italic) result 200).
* http://github.com/ with 1 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* http://kafka.apache.org with 1 occurrences migrated to:  
  https://kafka.apache.org ([https](https://kafka.apache.org) result 200).
* http://kafka.apache.org/documentation.html with 1 occurrences migrated to:  
  https://kafka.apache.org/documentation.html ([https](https://kafka.apache.org/documentation.html) result 200).
* http://projectreactor.io/ with 1 occurrences migrated to:  
  https://projectreactor.io/ ([https](https://projectreactor.io/) result 200).
* http://projectreactor.io/assets/img/logo-2x.png with 1 occurrences migrated to:  
  https://projectreactor.io/assets/img/logo-2x.png ([https](https://projectreactor.io/assets/img/logo-2x.png) result 200).
* http://www.apache.org/ with 1 occurrences migrated to:  
  https://www.apache.org/ ([https](https://www.apache.org/) result 200).
* http://www.oracle.com/technetwork/java/javase/downloads/index.html with 1 occurrences migrated to:  
  https://www.oracle.com/technetwork/java/javase/downloads/index.html ([https](https://www.oracle.com/technetwork/java/javase/downloads/index.html) result 200).
* http://kafka.apache.org/documentation with 3 occurrences migrated to:  
  https://kafka.apache.org/documentation ([https](https://kafka.apache.org/documentation) result 301).
* http://openshift.redhat.com/app/assets-20130701203230/overpass.css with 1 occurrences migrated to:  
  https://openshift.redhat.com/app/assets-20130701203230/overpass.css ([https](https://openshift.redhat.com/app/assets-20130701203230/overpass.css) result 301).
* http://oreilly.com with 1 occurrences migrated to:  
  https://oreilly.com ([https](https://oreilly.com) result 301).
* http://repo.spring.io/milestone with 1 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).