### PR TITLE
Receiver exception handler

### DIFF
--- a/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
@@ -32,6 +32,8 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.Deserializer;
 import reactor.core.scheduler.Scheduler;
+import reactor.kafka.receiver.errors.LogAndFailReceiverExceptionHandler;
+import reactor.kafka.receiver.errors.ReceiverExceptionHandler;
 
 class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
 
@@ -52,6 +54,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
     private final Collection<TopicPartition> assignTopicPartitions;
     private final Pattern subscribePattern;
     private final Supplier<Scheduler> schedulerSupplier;
+    private final ReceiverExceptionHandler receiverExceptionHandler;
 
     ImmutableReceiverOptions(ReceiverOptions<K, V> options) {
         this(
@@ -69,7 +72,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
             options.subscriptionTopics(),
             options.assignment(),
             options.subscriptionPattern(),
-            options.schedulerSupplier()
+            options.schedulerSupplier(),
+            options.receiverExceptionHandler()
         );
     }
 
@@ -88,7 +92,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
         Collection<String> topics,
         Collection<TopicPartition> partitions,
         Pattern pattern,
-        Supplier<Scheduler> supplier
+        Supplier<Scheduler> supplier,
+        ReceiverExceptionHandler receiverExceptionHandler
     ) {
         this.properties = new HashMap<>(properties);
         this.assignListeners = new ArrayList<>(assignListeners);
@@ -105,6 +110,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
         this.assignTopicPartitions = partitions == null ? null : new HashSet<>(partitions);
         this.subscribePattern = pattern;
         this.schedulerSupplier = supplier;
+        this.receiverExceptionHandler = receiverExceptionHandler == null ? new LogAndFailReceiverExceptionHandler() : receiverExceptionHandler;
     }
 
     @Override
@@ -140,7 +146,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -161,7 +168,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -187,7 +195,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -221,7 +230,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -250,7 +260,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -276,7 +287,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -302,7 +314,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -323,7 +336,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -344,7 +358,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -375,7 +390,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 Objects.requireNonNull(topics),
                 null,
                 null,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -396,7 +412,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 null,
                 null,
                 Objects.requireNonNull(pattern),
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -417,7 +434,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 null,
                 Objects.requireNonNull(partitions),
                 null,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -473,7 +491,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -502,7 +521,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -531,7 +551,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -560,7 +581,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                schedulerSupplier
+                schedulerSupplier,
+                receiverExceptionHandler
         );
     }
 
@@ -586,7 +608,35 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
-                Objects.requireNonNull(schedulerSupplier)
+                Objects.requireNonNull(schedulerSupplier),
+                receiverExceptionHandler
+        );
+    }
+
+    @Override
+    public ReceiverExceptionHandler receiverExceptionHandler() {
+        return receiverExceptionHandler;
+    }
+
+    @Override
+    public ReceiverOptions<K, V> receiverExceptionHandler(ReceiverExceptionHandler receiverExceptionHandler) {
+        return new ImmutableReceiverOptions<>(
+                properties,
+                assignListeners,
+                revokeListeners,
+                keyDeserializer,
+                valueDeserializer,
+                pollTimeout,
+                closeTimeout,
+                commitInterval,
+                commitBatchSize,
+                atmostOnceCommitAheadSize,
+                maxCommitAttempts,
+                subscribeTopics,
+                assignTopicPartitions,
+                subscribePattern,
+                schedulerSupplier,
+                Objects.requireNonNull(receiverExceptionHandler)
         );
     }
 

--- a/src/main/java/reactor/kafka/receiver/MutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/MutableReceiverOptions.java
@@ -36,6 +36,8 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.Deserializer;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
+import reactor.kafka.receiver.errors.LogAndFailReceiverExceptionHandler;
+import reactor.kafka.receiver.errors.ReceiverExceptionHandler;
 
 /**
  * Configuration properties for Reactive Kafka {@link KafkaReceiver} and its underlying {@link KafkaConsumer}.
@@ -66,6 +68,7 @@ class MutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
     private Collection<TopicPartition> assignTopicPartitions;
     private Pattern subscribePattern;
     private Supplier<Scheduler> schedulerSupplier;
+    private ReceiverExceptionHandler receiverExceptionHandler;
 
     MutableReceiverOptions() {
         this(new HashMap<>());
@@ -95,6 +98,7 @@ class MutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
         maxCommitAttempts = DEFAULT_MAX_COMMIT_ATTEMPTS;
         properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         schedulerSupplier = Schedulers::parallel;
+        receiverExceptionHandler = new LogAndFailReceiverExceptionHandler();
     }
 
     /**
@@ -522,6 +526,25 @@ class MutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
     @Override
     public ReceiverOptions<K, V> schedulerSupplier(Supplier<Scheduler> schedulerSupplier) {
         this.schedulerSupplier = Objects.requireNonNull(schedulerSupplier);
+        return this;
+    }
+
+    /**
+     * Returns the Exception Handler for receiver errors
+     * @return Receiver Exception Handler for receiver errors
+     */
+    @Override
+    public ReceiverExceptionHandler receiverExceptionHandler() {
+        return receiverExceptionHandler;
+    }
+
+    /**
+     * Configures the Exception Handler for receiver errors
+     * @return options instance with updated receiver exception handler
+     */
+    @Override
+    public ReceiverOptions<K, V> receiverExceptionHandler(ReceiverExceptionHandler receiverExceptionHandler) {
+        this.receiverExceptionHandler = receiverExceptionHandler;
         return this;
     }
 

--- a/src/main/java/reactor/kafka/receiver/ReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverOptions.java
@@ -17,6 +17,7 @@ import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Deserializer;
 import reactor.core.scheduler.Scheduler;
+import reactor.kafka.receiver.errors.ReceiverExceptionHandler;
 import reactor.util.annotation.NonNull;
 import reactor.util.annotation.Nullable;
 
@@ -227,6 +228,13 @@ public interface ReceiverOptions<K, V> {
     ReceiverOptions<K, V> schedulerSupplier(Supplier<Scheduler> schedulerSupplier);
 
     /**
+     * Configures the Exception Handler for receiver errors
+     * @return options instance with updated receiver exception handler
+     */
+    @NonNull
+    ReceiverOptions<K, V> receiverExceptionHandler(ReceiverExceptionHandler receiverExceptionHandler);
+
+    /**
      * Returns the configuration properties of the underlying {@link KafkaConsumer}.
      * @return options to configure for Kafka consumer.
      */
@@ -361,6 +369,13 @@ public interface ReceiverOptions<K, V> {
      */
     @NonNull
     Supplier<Scheduler> schedulerSupplier();
+
+    /**
+     * Returns the Exception Handler for receiver errors
+     * @return Receiver Exception Handler for receiver errors
+     */
+    @NonNull
+    ReceiverExceptionHandler receiverExceptionHandler();
 
     /**
      * Returns the {@link KafkaConsumer#subscribe(Collection, ConsumerRebalanceListener)},

--- a/src/main/java/reactor/kafka/receiver/errors/LogAndContinueReceiverExceptionHandler.java
+++ b/src/main/java/reactor/kafka/receiver/errors/LogAndContinueReceiverExceptionHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016-2020 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.kafka.receiver.errors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Receiver exception handler that logs an exception and then continues (without failing).
+ */
+public class LogAndContinueReceiverExceptionHandler implements ReceiverExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(LogAndContinueReceiverExceptionHandler.class);
+
+    @Override
+    public ReceiverExceptionHandlerResponse handle(final Exception exception) {
+        log.warn("Receiver exception caught: {}",
+                  exception.getLocalizedMessage(),
+                  exception);
+
+        return ReceiverExceptionHandlerResponse.CONTINUE;
+    }
+
+}

--- a/src/main/java/reactor/kafka/receiver/errors/LogAndFailReceiverExceptionHandler.java
+++ b/src/main/java/reactor/kafka/receiver/errors/LogAndFailReceiverExceptionHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016-2020 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.kafka.receiver.errors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Receiver exception handler that logs an exception and then fails.
+ */
+public class LogAndFailReceiverExceptionHandler implements ReceiverExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(LogAndFailReceiverExceptionHandler.class);
+
+    @Override
+    public ReceiverExceptionHandlerResponse handle(final Exception exception) {
+        log.error("Receiver exception caught: {}",
+                  exception.getLocalizedMessage(),
+                  exception);
+
+        return ReceiverExceptionHandlerResponse.FAIL;
+    }
+
+}

--- a/src/main/java/reactor/kafka/receiver/errors/ReceiverExceptionHandler.java
+++ b/src/main/java/reactor/kafka/receiver/errors/ReceiverExceptionHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016-2020 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.kafka.receiver.errors;
+
+/**
+ * Interface that specifies how an exception thrown by Kafka Receiver
+ * (e.g., failing to commit to Kafka) should be handled.
+ */
+public interface ReceiverExceptionHandler {
+
+    /**
+     * Inspect the exception received.
+     * @param exception the actual exception
+     */
+    ReceiverExceptionHandlerResponse handle(final Exception exception);
+
+    /**
+     * Enumeration that describes the response from the exception handler.
+     */
+    enum ReceiverExceptionHandlerResponse {
+        /* continue with processing */
+        CONTINUE,
+        /* fail the processing and stop */
+        FAIL
+    }
+
+}


### PR DESCRIPTION
Added ReceiverExceptionHandler interface and two implementations (LogAndFail and LogAndContinue).

Based on KIP-161 for kafka-streams.

Default implemtation is LogAndFailReceiverExceptionHandler: same behavior as before, i.e. log the exception (ERROR level) and call error(Throwable e) on the consumer records Flux Sink.

LogAndContinueReceiverExceptionHandler logs the exceptions (WARN level) but does NOT call error(Throwable e), as proposed by @yevtsy and @gzeskas (issue #49).

Should fix issue #49 (setting LogAndContinueReceiverExceptionHandler as the exception handler).