### PR TITLE
Switch master to 1.2.0 / Dysprosium

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ With Gradle from repo.spring.io:
     }
 
     dependencies {
-      //compile "io.projectreactor.kafka:reactor-kafka:1.1.2.BUILD-SNAPSHOT"
-      compile "io.projectreactor.kafka:reactor-kafka:1.1.1.RELEASE"
+      compile "io.projectreactor.kafka:reactor-kafka:1.2.0.BUILD-SNAPSHOT"
+//      compile "io.projectreactor.kafka:reactor-kafka:1.1.1.RELEASE"
     }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
 
   kafkaVersion = '2.0.0'
   scalaVersion = '2.11'
-  reactorVersion = '3.2.10.BUILD-SNAPSHOT'
+  reactorVersion = '3.3.0.BUILD-SNAPSHOT'
   metricsVersion = '2.2.0'
 
   argparseVersion = '0.5.0'
@@ -50,6 +50,7 @@ ext {
                   "https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/",
                   "https://projectreactor.io/docs/core/release/api/"] as String[]
 
+  
 }
 
 apply from: "$gradleScriptDir/setup.gradle"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1.2.BUILD-SNAPSHOT
+version=1.2.0.BUILD-SNAPSHOT


### PR DESCRIPTION
`1.1.x` has been branched out. We'll need to make sure if 3.3.0 adjustments are in order.