### PR TITLE
Introduce `ConsumerHandler` abstraction

### DIFF
--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerFlux.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerFlux.java
@@ -53,12 +53,12 @@ class ConsumerFlux<K, V> extends Flux<ConsumerRecords<K, V>> {
 
     final Predicate<Throwable> isRetriableException;
 
-    final AtomicBoolean awaitingTransaction;
-
     // TODO make it final
     org.apache.kafka.clients.consumer.Consumer<K, V> consumer;
 
     CoreSubscriber<? super ConsumerRecords<K, V>> actual;
+
+    final AtomicBoolean awaitingTransaction;
 
     ConsumerFlux(
         AckMode ackMode,

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerFlux.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerFlux.java
@@ -16,54 +16,26 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
 import reactor.core.publisher.Operators;
 import reactor.core.scheduler.Scheduler;
-import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.receiver.ReceiverOffset;
 import reactor.kafka.receiver.ReceiverOptions;
 import reactor.kafka.receiver.ReceiverPartition;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Proxy;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 class ConsumerFlux<K, V> extends Flux<ConsumerRecords<K, V>> {
 
     private static final Logger log = LoggerFactory.getLogger(ConsumerFlux.class.getName());
-
-    /** Note: Methods added to this set should also be included in javadoc for {@link KafkaReceiver#doOnConsumer(Function)} */
-    private static final Set<String> DELEGATE_METHODS = new HashSet<>(Arrays.asList(
-        "assignment",
-        "subscription",
-        "seek",
-        "seekToBeginning",
-        "seekToEnd",
-        "position",
-        "committed",
-        "metrics",
-        "partitionsFor",
-        "listTopics",
-        "paused",
-        "pause",
-        "resume",
-        "offsetsForTimes",
-        "beginningOffsets",
-        "endOffsets"
-    ));
 
     final AtomicBoolean isActive = new AtomicBoolean();
 
@@ -75,35 +47,34 @@ class ConsumerFlux<K, V> extends Flux<ConsumerRecords<K, V>> {
 
     final ReceiverOptions<K, V> receiverOptions;
 
-    final ConsumerFactory consumerFactory;
-
     final Scheduler eventScheduler;
 
     final CommitEvent commitEvent = new CommitEvent();
 
     final Predicate<Throwable> isRetriableException;
 
+    final AtomicBoolean awaitingTransaction;
+
+    // TODO make it final
     org.apache.kafka.clients.consumer.Consumer<K, V> consumer;
 
-    org.apache.kafka.clients.consumer.Consumer<K, V> consumerProxy;
-
     CoreSubscriber<? super ConsumerRecords<K, V>> actual;
-
-    AtomicBoolean awaitingTransaction;
 
     ConsumerFlux(
         AckMode ackMode,
         ReceiverOptions<K, V> receiverOptions,
-        ConsumerFactory consumerFactory,
-        Predicate<Throwable> isRetriableException
+        Scheduler eventScheduler, org.apache.kafka.clients.consumer.Consumer<K, V> consumer,
+        Predicate<Throwable> isRetriableException,
+        AtomicBoolean awaitingTransaction
     ) {
         this.ackMode = ackMode;
         this.receiverOptions = receiverOptions;
-        this.consumerFactory = consumerFactory;
+        this.eventScheduler = eventScheduler;
+        this.consumer = consumer;
         this.isRetriableException = isRetriableException;
+        this.awaitingTransaction = awaitingTransaction;
 
         pollEvent = new PollEvent();
-        eventScheduler = KafkaSchedulers.newEvent(receiverOptions.groupId());
     }
 
     @Override
@@ -117,13 +88,7 @@ class ConsumerFlux<K, V> extends Flux<ConsumerRecords<K, V>> {
 
         this.actual = actual;
 
-        awaitingTransaction = actual.currentContext().getOrDefault(
-            DefaultKafkaReceiver.AWAITING_TRANSACTION_KEY,
-            null
-        );
-
         try {
-            consumer = consumerFactory.createConsumer(receiverOptions);
             eventScheduler.schedule(new SubscribeEvent());
 
             Duration commitInterval = receiverOptions.commitInterval();
@@ -246,12 +211,6 @@ class ConsumerFlux<K, V> extends Flux<ConsumerRecords<K, V>> {
         }
     }
 
-    <T> Mono<T> doOnConsumer(Function<org.apache.kafka.clients.consumer.Consumer<K, V>, ? extends T> function) {
-        return Mono.create(monoSink -> {
-            eventScheduler.schedule(new CustomEvent<T>(function, monoSink));
-        });
-    }
-
     Mono<Void> commit(ConsumerRecord<K, V> r) {
         long offset = r.offset();
         TopicPartition partition = new TopicPartition(r.topic(), r.partition());
@@ -328,7 +287,7 @@ class ConsumerFlux<K, V> extends Flux<ConsumerRecords<K, V>> {
                     commitEvent.runIfRequired(false);
                     pendingCount.decrementAndGet();
                     if (requestsPending.get() > 0) {
-                        if (awaitingTransaction == null || !awaitingTransaction.get()) {
+                        if (!awaitingTransaction.get()) {
                             if (partitionsPaused.getAndSet(false)) {
                                 consumer.resume(consumer.assignment());
                             }
@@ -472,50 +431,6 @@ class ConsumerFlux<K, V> extends Flux<ConsumerRecords<K, V>> {
         }
     }
 
-    class CustomEvent<T> implements Runnable {
-        private final Function<org.apache.kafka.clients.consumer.Consumer<K, V>, ? extends T> function;
-        private final MonoSink<T> monoSink;
-        CustomEvent(
-            Function<org.apache.kafka.clients.consumer.Consumer<K, V>, ? extends T> function,
-            MonoSink<T> monoSink
-        ) {
-            this.function = function;
-            this.monoSink = monoSink;
-        }
-        @Override
-        public void run() {
-            if (isActive.get()) {
-                try {
-                    T ret = function.apply(consumerProxy());
-                    monoSink.success(ret);
-                } catch (Throwable e) {
-                    monoSink.error(e);
-                }
-            }
-        }
-
-        @SuppressWarnings("unchecked")
-        private org.apache.kafka.clients.consumer.Consumer<K, V> consumerProxy() {
-            if (consumerProxy == null) {
-                Class<?>[] interfaces = new Class<?>[]{org.apache.kafka.clients.consumer.Consumer.class};
-                InvocationHandler handler = (proxy, method, args) -> {
-                    if (DELEGATE_METHODS.contains(method.getName())) {
-                        try {
-                            return method.invoke(consumer, args);
-                        } catch (InvocationTargetException e) {
-                            throw e.getCause();
-                        }
-                    } else
-                        throw new UnsupportedOperationException("Method is not supported: " + method);
-                };
-                consumerProxy = (org.apache.kafka.clients.consumer.Consumer<K, V>) Proxy.newProxyInstance(
-                    org.apache.kafka.clients.consumer.Consumer.class.getClassLoader(),
-                    interfaces,
-                    handler);
-            }
-            return consumerProxy;
-        }
-    }
     private class CloseEvent implements Runnable {
         private final long closeEndTimeNanos;
         private final CountDownLatch latch = new CountDownLatch(1);

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerFlux.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerFlux.java
@@ -211,21 +211,6 @@ class ConsumerFlux<K, V> extends Flux<ConsumerRecords<K, V>> {
         }
     }
 
-    Mono<Void> commit(ConsumerRecord<K, V> r) {
-        long offset = r.offset();
-        TopicPartition partition = new TopicPartition(r.topic(), r.partition());
-        long committedOffset = atmostOnceOffsets.committedOffset(partition);
-        atmostOnceOffsets.onDispatch(partition, offset);
-        long commitAheadSize = receiverOptions.atmostOnceCommitAheadSize();
-        ReceiverOffset committable = new CommittableOffset(partition, offset + commitAheadSize);
-        if (offset >= committedOffset) {
-            return committable.commit();
-        } else if (committedOffset - offset >= commitAheadSize / 2) {
-            committable.commit().subscribe();
-        }
-        return Mono.empty();
-    }
-
     private void onError(Throwable t) {
         CoreSubscriber<? super ConsumerRecords<K, V>> actual = this.actual;
         try {

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
@@ -1,0 +1,148 @@
+package reactor.kafka.receiver.internals;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.kafka.receiver.KafkaReceiver;
+import reactor.kafka.receiver.ReceiverOptions;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A helper class that holds the state of a current receive "session".
+ * To be exposed as a public class in the next major version (a subject to the API review).
+ */
+class ConsumerHandler<K, V> {
+
+    /** Note: Methods added to this set should also be included in javadoc for {@link KafkaReceiver#doOnConsumer(Function)} */
+    private static final Set<String> DELEGATE_METHODS = new HashSet<>(Arrays.asList(
+        "assignment",
+        "subscription",
+        "seek",
+        "seekToBeginning",
+        "seekToEnd",
+        "position",
+        "committed",
+        "metrics",
+        "partitionsFor",
+        "listTopics",
+        "paused",
+        "pause",
+        "resume",
+        "offsetsForTimes",
+        "beginningOffsets",
+        "endOffsets"
+    ));
+
+    final AtomicBoolean awaitingTransaction = new AtomicBoolean();
+
+    private final ReceiverOptions<K, V> receiverOptions;
+
+    private final Predicate<Throwable> isRetriableException;
+
+    final Scheduler scheduler;
+
+    private final Consumer<K, V> consumer;
+
+    private final Scheduler eventScheduler;
+
+    private ConsumerFlux<K, V> consumerFlux;
+
+    private Consumer<K, V> consumerProxy;
+
+    ConsumerHandler(
+        ReceiverOptions<K, V> receiverOptions,
+        Consumer<K, V> consumer,
+        Predicate<Throwable> isRetriableException
+    ) {
+        this.receiverOptions = receiverOptions;
+        this.consumer = consumer;
+        this.isRetriableException = isRetriableException;
+
+        scheduler = Schedulers.single(receiverOptions.schedulerSupplier().get());
+        eventScheduler = KafkaSchedulers.newEvent(receiverOptions.groupId());
+    }
+
+    public Flux<ConsumerRecords<K, V>> receive(AckMode ackMode) {
+        consumerFlux = new ConsumerFlux<>(
+            ackMode,
+            receiverOptions,
+            eventScheduler,
+            consumer,
+            isRetriableException,
+            awaitingTransaction
+        );
+        return consumerFlux
+            .onBackpressureBuffer()
+            .publishOn(scheduler);
+    }
+
+    public Mono<Void> close() {
+        return Mono.fromRunnable(scheduler::dispose);
+    }
+
+    public <T> Mono<T> doOnConsumer(Function<Consumer<K, V>, ? extends T> function) {
+        return Mono.create(monoSink -> {
+            Disposable disposable = eventScheduler.schedule(() -> {
+                try {
+                    T result = function.apply(consumerProxy());
+                    monoSink.success(result);
+                } catch (Exception e) {
+                    monoSink.error(e);
+                }
+            });
+            monoSink.onCancel(disposable);
+        });
+    }
+
+    public void handleRequest(long r) {
+        consumerFlux.handleRequest(r);
+    }
+
+    public Mono<Void> commit(ConsumerRecord<K, V> record) {
+        return consumerFlux.commit(record);
+    }
+
+    public void acknowledge(ConsumerRecord<K, V> record) {
+        consumerFlux.new CommittableOffset(record).acknowledge();
+    }
+
+    public ConsumerFlux<K, V>.CommittableOffset toCommittableOffset(ConsumerRecord<K, V> record) {
+        return consumerFlux.new CommittableOffset(record);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Consumer<K, V> consumerProxy() {
+        if (consumerProxy != null) {
+            return consumerProxy;
+        }
+
+        Class<?>[] interfaces = new Class<?>[]{Consumer.class};
+        InvocationHandler handler = (proxy, method, args) -> {
+            if (DELEGATE_METHODS.contains(method.getName())) {
+                try {
+                    return method.invoke(consumer, args);
+                } catch (InvocationTargetException e) {
+                    throw e.getCause();
+                }
+            } else {
+                throw new UnsupportedOperationException("Method is not supported: " + method);
+            }
+        };
+        consumerProxy = (Consumer<K, V>) Proxy.newProxyInstance(Consumer.class.getClassLoader(), interfaces, handler);
+        return consumerProxy;
+    }
+}

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
@@ -61,6 +61,8 @@ class ConsumerHandler<K, V> {
 
     private final Scheduler eventScheduler;
 
+    private final AckMode ackMode;
+
     private ConsumerFlux<K, V> consumerFlux;
 
     private Consumer<K, V> consumerProxy;
@@ -68,17 +70,19 @@ class ConsumerHandler<K, V> {
     ConsumerHandler(
         ReceiverOptions<K, V> receiverOptions,
         Consumer<K, V> consumer,
-        Predicate<Throwable> isRetriableException
+        Predicate<Throwable> isRetriableException,
+        AckMode ackMode
     ) {
         this.receiverOptions = receiverOptions;
         this.consumer = consumer;
         this.isRetriableException = isRetriableException;
+        this.ackMode = ackMode;
 
         scheduler = Schedulers.single(receiverOptions.schedulerSupplier().get());
         eventScheduler = KafkaSchedulers.newEvent(receiverOptions.groupId());
     }
 
-    public Flux<ConsumerRecords<K, V>> receive(AckMode ackMode) {
+    public Flux<ConsumerRecords<K, V>> receive() {
         consumerFlux = new ConsumerFlux<>(
             ackMode,
             receiverOptions,

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
@@ -53,17 +53,13 @@ class ConsumerHandler<K, V> {
 
     private final ReceiverOptions<K, V> receiverOptions;
 
-    private final Predicate<Throwable> isRetriableException;
-
     final Scheduler scheduler;
 
     private final Consumer<K, V> consumer;
 
     private final Scheduler eventScheduler;
 
-    private final AckMode ackMode;
-
-    private ConsumerFlux<K, V> consumerFlux;
+    private final ConsumerFlux<K, V> consumerFlux;
 
     private Consumer<K, V> consumerProxy;
 
@@ -75,14 +71,10 @@ class ConsumerHandler<K, V> {
     ) {
         this.receiverOptions = receiverOptions;
         this.consumer = consumer;
-        this.isRetriableException = isRetriableException;
-        this.ackMode = ackMode;
 
         scheduler = Schedulers.single(receiverOptions.schedulerSupplier().get());
         eventScheduler = KafkaSchedulers.newEvent(receiverOptions.groupId());
-    }
 
-    public Flux<ConsumerRecords<K, V>> receive() {
         consumerFlux = new ConsumerFlux<>(
             ackMode,
             receiverOptions,
@@ -91,6 +83,9 @@ class ConsumerHandler<K, V> {
             isRetriableException,
             awaitingTransaction
         );
+    }
+
+    public Flux<ConsumerRecords<K, V>> receive() {
         return consumerFlux
             .onBackpressureBuffer()
             .publishOn(scheduler);

--- a/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
@@ -70,7 +70,7 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V> {
                     ))
                     .doOnRequest(handler::handleRequest);
             },
-            this::dispose
+            this::cleanup
         );
     }
 
@@ -91,7 +91,7 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V> {
                             });
                     });
             },
-            this::dispose
+            this::cleanup
         );
     }
 
@@ -114,7 +114,7 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V> {
                     }, Integer.MAX_VALUE)
                     .doOnRequest(handler::handleRequest);
             },
-            this::dispose
+            this::cleanup
         );
     }
 
@@ -145,7 +145,7 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V> {
                     })
                     .publishOn(transactionManager.scheduler());
             },
-            this::dispose
+            this::cleanup
         );
     }
 
@@ -158,7 +158,7 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V> {
         return consumerHandler.doOnConsumer(function);
     }
 
-    private Mono<Void> dispose(ConsumerHandler<K, V> handler) {
+    private Mono<Void> cleanup(ConsumerHandler<K, V> handler) {
         return handler.close().doFinally(__ -> consumerHandler = null);
     }
 }

--- a/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
@@ -15,7 +15,6 @@
  */
 package reactor.kafka.receiver.internals;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -25,135 +24,140 @@ import org.apache.kafka.common.TopicPartition;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Scheduler;
-import reactor.core.scheduler.Schedulers;
 import reactor.kafka.receiver.ReceiverOptions;
 import reactor.kafka.receiver.ReceiverRecord;
 import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.sender.TransactionManager;
-import reactor.util.context.Context;
 
 public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V> {
-
-    static final String AWAITING_TRANSACTION_KEY = "reactor.kafka.receiver.internals.awaitingTransaction";
 
     private final ConsumerFactory consumerFactory;
 
     private final ReceiverOptions<K, V> receiverOptions;
 
-    private Scheduler scheduler;
-
-    ConsumerFlux<K, V> consumerFlux;
-
     Predicate<Throwable> isRetriableException = RetriableCommitFailedException.class::isInstance;
+
+    ConsumerHandler<K, V> consumerHandler;
 
     public DefaultKafkaReceiver(ConsumerFactory consumerFactory, ReceiverOptions<K, V> receiverOptions) {
         this.consumerFactory = consumerFactory;
         this.receiverOptions = receiverOptions.toImmutable();
     }
 
+    private Mono<ConsumerHandler<K, V>> start() {
+        return Mono.fromCallable(() -> {
+            return consumerHandler = new ConsumerHandler<>(
+                receiverOptions,
+                consumerFactory.createConsumer(receiverOptions),
+                // Always use the currently set value
+                e -> isRetriableException.test(e)
+            );
+        });
+    }
+
     @Override
     public Flux<ReceiverRecord<K, V>> receive() {
-        ConsumerFlux<K, V> consumerFlux = createConsumerFlux(AckMode.MANUAL_ACK);
-        return consumerFlux
-            .onBackpressureBuffer()
-            .publishOn(scheduler)
-            .doFinally(signal -> dispose())
-            .flatMapIterable(it -> it)
-            .map(record -> new ReceiverRecord<>(
-                record,
-                consumerFlux.new CommittableOffset(record)
-            ))
-            .doOnRequest(consumerFlux::handleRequest);
+        return Flux.usingWhen(
+            start(),
+            handler -> {
+                return handler
+                    .receive(AckMode.MANUAL_ACK)
+                    .flatMapIterable(it -> it)
+                    .map(record -> new ReceiverRecord<>(
+                        record,
+                        handler.toCommittableOffset(record)
+                    ))
+                    .doOnRequest(handler::handleRequest);
+            },
+            this::dispose
+        );
     }
 
     @Override
     public Flux<Flux<ConsumerRecord<K, V>>> receiveAutoAck() {
-        ConsumerFlux<K, V> consumerFlux = createConsumerFlux(AckMode.AUTO_ACK);
-        return consumerFlux
-            .onBackpressureBuffer()
-            .publishOn(scheduler)
-            .doFinally(signal -> dispose())
-            .doOnRequest(consumerFlux::handleRequest)
-            .map(consumerRecords -> {
-                return Flux.fromIterable(consumerRecords)
-                    .doAfterTerminate(() -> {
-                        for (ConsumerRecord<K, V> r : consumerRecords) {
-                            consumerFlux.new CommittableOffset(r).acknowledge();
-                        }
+        return Flux.usingWhen(
+            start(),
+            handler -> {
+                return handler
+                    .receive(AckMode.AUTO_ACK)
+                    .doOnRequest(handler::handleRequest)
+                    .map(consumerRecords -> {
+                        return Flux.fromIterable(consumerRecords)
+                            .doAfterTerminate(() -> {
+                                for (ConsumerRecord<K, V> r : consumerRecords) {
+                                    handler.acknowledge(r);
+                                }
+                            });
                     });
-            });
+            },
+            this::dispose
+        );
     }
 
     @Override
     public Flux<ConsumerRecord<K, V>> receiveAtmostOnce() {
-        ConsumerFlux<K, V> consumerFlux = createConsumerFlux(AckMode.ATMOST_ONCE);
-        return consumerFlux
-            .onBackpressureBuffer()
-            .publishOn(scheduler)
-            .doFinally(signal -> dispose())
-            .concatMap(records -> {
-                return Flux
-                    .fromIterable(records)
-                    .concatMap(r -> {
-                        return consumerFlux.commit(r)
-                            // TODO remove?
-                            .publishOn(scheduler)
-                            .thenReturn(r);
-                    }, Integer.MAX_VALUE);
-            }, Integer.MAX_VALUE)
-            .doOnRequest(consumerFlux::handleRequest);
+        return Flux.usingWhen(
+            start(),
+            handler -> {
+                return handler
+                    .receive(AckMode.ATMOST_ONCE)
+                    .concatMap(records -> {
+                        return Flux
+                            .fromIterable(records)
+                            .concatMap(r -> {
+                                return handler.commit(r)
+                                    // TODO remove?
+                                    .publishOn(handler.scheduler)
+                                    .thenReturn(r);
+                            }, Integer.MAX_VALUE);
+                    }, Integer.MAX_VALUE)
+                    .doOnRequest(handler::handleRequest);
+            },
+            this::dispose
+        );
     }
 
     @Override
     public Flux<Flux<ConsumerRecord<K, V>>> receiveExactlyOnce(TransactionManager transactionManager) {
-        ConsumerFlux<K, V> consumerFlux = createConsumerFlux(AckMode.EXACTLY_ONCE);
-        AtomicBoolean awaitingTransaction = new AtomicBoolean();
-        return consumerFlux
-            .subscriberContext(Context.of(AWAITING_TRANSACTION_KEY, awaitingTransaction))
-            .onBackpressureBuffer()
-            .publishOn(scheduler)
-            .doFinally(signal -> dispose())
-            .doOnRequest(consumerFlux::handleRequest)
-            .map(consumerRecords -> {
-                if (consumerRecords.isEmpty()) {
-                    return Flux.<ConsumerRecord<K, V>>empty();
-                }
-                CommittableBatch offsetBatch = new CommittableBatch();
-                for (ConsumerRecord<K, V> r : consumerRecords) {
-                    offsetBatch.updateOffset(new TopicPartition(r.topic(), r.partition()), r.offset());
-                }
+        return Flux.usingWhen(
+            start(),
+            handler -> {
+                return handler
+                    .receive(AckMode.EXACTLY_ONCE)
+                    .doOnRequest(handler::handleRequest)
+                    .map(consumerRecords -> {
+                        if (consumerRecords.isEmpty()) {
+                            return Flux.<ConsumerRecord<K, V>>empty();
+                        }
+                        CommittableBatch offsetBatch = new CommittableBatch();
+                        for (ConsumerRecord<K, V> r : consumerRecords) {
+                            offsetBatch.updateOffset(new TopicPartition(r.topic(), r.partition()), r.offset());
+                        }
 
-                return transactionManager.begin()
-                    .thenMany(Flux.defer(() -> {
-                        awaitingTransaction.getAndSet(true);
-                        return Flux.fromIterable(consumerRecords);
-                    }))
-                    .concatWith(transactionManager.sendOffsets(offsetBatch.getAndClearOffsets().offsets(), receiverOptions.groupId()))
-                    .doAfterTerminate(() -> awaitingTransaction.set(false));
-            })
-            .publishOn(transactionManager.scheduler());
+                        return transactionManager.begin()
+                            .thenMany(Flux.defer(() -> {
+                                handler.awaitingTransaction.getAndSet(true);
+                                return Flux.fromIterable(consumerRecords);
+                            }))
+                            .concatWith(transactionManager.sendOffsets(offsetBatch.getAndClearOffsets().offsets(), receiverOptions.groupId()))
+                            .doAfterTerminate(() -> handler.awaitingTransaction.set(false));
+                    })
+                    .publishOn(transactionManager.scheduler());
+            },
+            this::dispose
+        );
     }
 
     @Override
     public <T> Mono<T> doOnConsumer(Function<org.apache.kafka.clients.consumer.Consumer<K, V>, ? extends T> function) {
-        return Mono.defer(() -> consumerFlux.doOnConsumer(function));
+        if (consumerHandler == null) {
+            // TODO deprecate this method, expose ConsumerHandler
+            return Mono.error(new IllegalStateException("You must call one of receive*() methods before using doOnConsumer"));
+        }
+        return consumerHandler.doOnConsumer(function);
     }
 
-    private synchronized ConsumerFlux<K, V> createConsumerFlux(AckMode ackMode) {
-        if (consumerFlux != null) {
-            throw new IllegalStateException("Multiple subscribers are not supported for KafkaReceiver flux");
-        }
-
-        scheduler = Schedulers.single(receiverOptions.schedulerSupplier().get());
-
-        return consumerFlux = new ConsumerFlux<>(ackMode, receiverOptions, consumerFactory, isRetriableException);
-    }
-
-    private synchronized void dispose() {
-        if (consumerFlux != null) {
-            scheduler.dispose();
-            consumerFlux = null;
-        }
+    private Mono<Void> dispose(ConsumerHandler<K, V> handler) {
+        return handler.close().doFinally(__ -> consumerHandler = null);
     }
 }

--- a/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
@@ -1315,25 +1315,6 @@ public class MockReceiverTest {
         DefaultKafkaReceiver<Integer, String> receiver = new DefaultKafkaReceiver<>(consumerFactory, receiverOptions);
         Flux<ReceiverRecord<Integer, String>> inboundFlux = receiver.receive()
                 .doOnNext(r -> r.receiverOffset().acknowledge());
-        try {
-            receiver.receive();
-            fail("Multiple outstanding receives on the same receiver");
-        } catch (IllegalStateException e) {
-            // Expected exception
-        }
-        try {
-            receiver.receiveAtmostOnce();
-            fail("Multiple outstanding receives on the same receiver");
-        } catch (IllegalStateException e) {
-            // Expected exception
-        }
-
-        try {
-            receiver.receiveAutoAck();
-            fail("Multiple outstanding receives on the same receiver");
-        } catch (IllegalStateException e) {
-            // Expected exception
-        }
 
         sendMessages(topic, 0, 10);
         receiveAndVerify(inboundFlux, 10);

--- a/src/test/java/reactor/kafka/receiver/internals/TestableReceiver.java
+++ b/src/test/java/reactor/kafka/receiver/internals/TestableReceiver.java
@@ -59,7 +59,7 @@ public class TestableReceiver {
         TestUtils.waitUntil(
             "KafkaReceiver not closed",
             null,
-            ignored -> kafkaReceiver.consumerFlux == null,
+            ignored -> kafkaReceiver.consumerHandler == null,
             null,
             Duration.ofMillis(10000)
         );


### PR DESCRIPTION
Since `KafkaReceiver` needs access to the internal state and also
call methods on it, returning just `ConsumerFlux` isn't a viable
option.
This will allow us to asynchronously pre-initialize the state
and access it after receiving an instance of the handler.