### PR TITLE
#175 Make fan-out scenario more reliable by using `tryEmitNext`

### DIFF
--- a/reactor-kafka-samples/src/test/java/reactor/kafka/samples/SampleScenariosTest.java
+++ b/reactor-kafka-samples/src/test/java/reactor/kafka/samples/SampleScenariosTest.java
@@ -247,7 +247,7 @@ public class SampleScenariosTest extends AbstractKafkaTest {
         disposables.add(flow.flux().subscribe());
         subscribeToDestTopic("group1", destTopic1, received1);
         subscribeToDestTopic("group2", destTopic2, received2);
-        sendMessages(sourceTopic, 20, expected1);
+        sendMessages(sourceTopic, 2000, expected1);
         for (Person p : expected1) {
             Person p2 = new Person(p.id(), p.firstName(), p.lastName());
             p2.email(flow.process2(p, false).value().email());

--- a/src/docs/asciidoc/examples.adoc
+++ b/src/docs/asciidoc/examples.adoc
@@ -162,28 +162,34 @@ The code segment below demonstrates fan-out with the same records processed in m
 streams. Each stream is processed on a different thread and which transforms the input record
 and stores the output in a Kafka topic.
 
-Reactor's https://projectreactor.io/docs/core/release/api/reactor/core/publisher/EmitterProcessor.html[EmitterProcessor]
+Reactor's https://projectreactor.io/docs/core/milestone/api/reactor/core/publisher/Sinks.MulticastSpec.html[Sinks.MulticastSpec]
 is used to broadcast the input records from Kafka to multiple subscribers.
+
+Please note that this sink honors downstream demand by conforming to the lowest demand in case
+of multiple subscribers.
 
 [source,java]
 --------
 
-EmitterProcessor<Person> processor = EmitterProcessor.create();         // <1>
-BlockingSink<Person> incoming = processor.connectSink();                // <2>
+Sinks.Many<Person> sink = Sinks.many().multicast().onBackpressureBuffer();         // <1>
 inputRecords = KafkaReceiver.create(receiverOptions)
                             .receive()
-                            .doOnNext(m -> incoming.emit(m.value()));   // <3>
+                            .doOnNext(m -> {
+                                while (sink.tryEmitNext(m.value()).hasFailed()) {  // <2>
+                                    LockSupport.parkNanos(10);                     // <3>
+                                }
+                            });
 
-outputRecords1 = processor.publishOn(scheduler1).map(p -> process1(p)); // <4>
-outputRecords2 = processor.publishOn(scheduler2).map(p -> process2(p)); // <5>
+outputRecords1 = processor.publishOn(scheduler1).map(p -> process1(p));            // <4>
+outputRecords2 = processor.publishOn(scheduler2).map(p -> process2(p));            // <5>
 
 Flux.merge(sender.send(outputRecords1), sender.send(outputRecords2))
     .doOnSubscribe(s -> inputRecords.subscribe())
-    .subscribe();                                                       // <6>
+    .subscribe();                                                                  // <6>
 --------
-<1> Create publish/subscribe EmitterProcessor for fan-out of Kafka inbound records
-<2> Create BlockingSink to which records are emitted
-<3> Receive from Kafka and emit to BlockingSink
+<1> Create publish/subscribe non-blocking multicast sink for fan-out of Kafka inbound records
+<2> Emit records using sink
+<3> Handle failures by retrying
 <4> Consume records on a scheduler, process and generate output records to send to Kafka
 <5> Add another processor for the same input data on a different scheduler
 <6> Merge the streams and subscribe to start the flow


### PR DESCRIPTION
Use `tryEmitNext` and handle the result as suggested in the deprecated `EmitterProcessor` 