### PR TITLE
Fix Partition Resumes

### DIFF
--- a/reactor-kafka-tools/src/test/resources/log4j.properties
+++ b/reactor-kafka-tools/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+# Copyright (c) 2020 VMware Inc, All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/reactor-kafka-tools/src/test/resources/log4j.properties
+++ b/reactor-kafka-tools/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 VMware Inc, All Rights Reserved.
+# Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
@@ -119,7 +119,7 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
 
     void onRequest(long toAdd) {
         if (log.isDebugEnabled()) {
-            log.debug("onRequest.toAdd:" + toAdd);
+            log.debug("onRequest.toAdd: " + toAdd);
         }
         Operators.addCap(REQUESTED, this, toAdd);
         pollEvent.schedule();
@@ -251,13 +251,13 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
                             if (!pausedByUs.getAndSet(true)) {
                                 this.pausedByUser.addAll(consumer.paused());
                                 consumer.pause(consumer.assignment());
-                                log.debug("Paused 1");
+                                log.debug("Paused - awaiting transaction");
                             }
                         }
                     } else if (!pausedByUs.getAndSet(true)) {
                         this.pausedByUser.addAll(consumer.paused());
                         consumer.pause(consumer.assignment());
-                        log.debug("Paused 2");
+                        log.debug("Paused - back pressure");
                     }
 
                     ConsumerRecords<K, V> records = consumer.poll(pollTimeout);

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
@@ -119,7 +119,7 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
 
     void onRequest(long toAdd) {
         if (log.isDebugEnabled()) {
-            log.debug("onRequest.toAdd: " + toAdd);
+            log.debug("onRequest.toAdd {}", toAdd);
         }
         Operators.addCap(REQUESTED, this, toAdd);
         pollEvent.schedule();
@@ -265,8 +265,11 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
                         schedule();
                     }
 
-                    Operators.produced(REQUESTED, ConsumerEventLoop.this, 1);
-                    sink.emitNext(records, ConsumerEventLoop.this);
+                    if (!records.isEmpty()) {
+                        Operators.produced(REQUESTED, ConsumerEventLoop.this, 1);
+                        log.debug("Emitting {} records, requested now {}", records.count(), r);
+                        sink.emitNext(records, ConsumerEventLoop.this);
+                    }
                 }
             } catch (Exception e) {
                 if (isActive.get()) {

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
@@ -227,12 +227,12 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
 
         private final Set<TopicPartition> pausedByUser = new HashSet<>();
 
-        private boolean scheduled;
+        private final AtomicBoolean scheduled = new AtomicBoolean();
 
         @Override
         public void run() {
             try {
-                scheduled = false;
+                this.scheduled.set(false);
                 if (isActive.get()) {
                     // Ensure that commits are not queued behind polls since number of poll events is
                     // chosen by reactor.
@@ -277,9 +277,8 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
         }
 
         void schedule() {
-            if (!this.scheduled) {
+            if (!this.scheduled.getAndSet(true)) {
                 eventScheduler.schedule(this);
-                this.scheduled = true;
             }
         }
     }

--- a/src/test/java/reactor/kafka/AbstractKafkaTest.java
+++ b/src/test/java/reactor/kafka/AbstractKafkaTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractKafkaTest {
 
     public static final int DEFAULT_TEST_TIMEOUT = 60_000;
 
-    private static final KafkaContainer KAFKA = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.1.0"))
+    private static final KafkaContainer KAFKA = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka"))
         .withNetwork(null)
         .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
         .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")

--- a/src/test/java/reactor/kafka/AbstractKafkaTest.java
+++ b/src/test/java/reactor/kafka/AbstractKafkaTest.java
@@ -15,19 +15,6 @@
  */
 package reactor.kafka;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
@@ -52,7 +39,6 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
-
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 import reactor.core.publisher.Flux;
@@ -61,11 +47,24 @@ import reactor.kafka.sender.SenderOptions;
 import reactor.kafka.sender.SenderRecord;
 import reactor.kafka.util.TestUtils;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public abstract class AbstractKafkaTest {
 
     public static final int DEFAULT_TEST_TIMEOUT = 60_000;
 
-    private static final KafkaContainer KAFKA = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.5.1"))
+    private static final KafkaContainer KAFKA = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.1.0"))
         .withNetwork(null)
         .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
         .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 VMware Inc, All Rights Reserved.
+# Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
`ConsumerEventLoop.PollEvent` should not resume partitions that it, itself,
has not paused.

Prior to https://github.com/reactor/reactor-kafka/commit/d908b815bf5a8be41b840a272e6766ad8754783d
pause/resume due to backpressure was protected by a boolean but it still unconditionally
resumed all partitions.

- reintroduce the boolean and only resume if we paused
- keep track of user-paused partitions and exclude them from resuming

Also fixes #190
Also fixes #198 