### PR TITLE
GH-193: Always Run close() on the Event Thread

### DIFF
--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
@@ -153,12 +153,9 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
                     return Mono.empty();
                 }
 
+                this.consumer.wakeup();
                 return Mono.<Void>fromRunnable(new CloseEvent(receiverOptions.closeTimeout()))
-                    .as(flux -> {
-                        return KafkaSchedulers.isCurrentThreadFromScheduler()
-                            ? flux
-                            : flux.subscribeOn(eventScheduler);
-                    });
+                    .as(flux -> flux.subscribeOn(eventScheduler));
             })
             .onErrorResume(e -> {
                 log.warn("Cancel exception: " + e);

--- a/src/test/java/reactor/kafka/receiver/internals/KafkaReceiverInternalTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/KafkaReceiverInternalTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 VMWare Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.kafka.receiver.internals;
+
+import org.junit.Test;
+import reactor.core.Disposable;
+import reactor.core.scheduler.Scheduler;
+import reactor.kafka.AbstractKafkaTest;
+import reactor.kafka.receiver.KafkaReceiver;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Gary Russell
+ * @since 1.3.3
+ *
+ */
+public class KafkaReceiverInternalTest extends AbstractKafkaTest {
+
+    @Test
+    public void closeForeignThread() throws InterruptedException {
+        this.receiverOptions = this.receiverOptions.pollTimeout(Duration.ofSeconds(60));
+        DefaultKafkaReceiver<Integer, String> receiver = createReceiver();
+        Disposable dispo = receiver.receive()
+                .doOnNext(rec -> { })
+                .subscribe();
+        Scheduler sched = KafkaSchedulers.newEvent("closeForeignThread2");
+        CountDownLatch latch = new CountDownLatch(1);
+        sched.schedule(() -> {
+            dispo.dispose();
+            latch.countDown();
+        });
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        /*
+         * Nothing to assert - the exception on close is just logged - see
+         * the error in the log before the fix.
+         */
+        sched.dispose();
+    }
+
+    private DefaultKafkaReceiver<Integer, String> createReceiver() {
+        this.receiverOptions = this.receiverOptions
+                .subscription(Collections.singletonList(this.topic));
+        return (DefaultKafkaReceiver<Integer, String>) KafkaReceiver.create(receiverOptions);
+    }
+
+}


### PR DESCRIPTION
Resolves https://github.com/reactor/reactor-kafka/issues/193

Previously, `ConsumerEventLoop.stop()` ran the close event on the
current thread, if that thread is a receiver thread. However, the
current thread could be for a different receiver.

Always schedule the `CloseEvent` on the loop's scheduler, and wake
the consumer since the thread might be suspended in `poll()`.

Also fixes a race condition in another test.