### PR TITLE
Memory usage patch

### DIFF
--- a/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
@@ -74,9 +74,14 @@ public interface KafkaReceiver<K, V> {
      * based on the configured commit interval and commit batch size in {@link ReceiverOptions}.
      * Records may also be committed manually using {@link ReceiverOffset#commit()}.
      *
+     * @param prefetch amount of prefetched batches
      * @return Flux of inbound receiver records that are committed only after acknowledgement
      */
-    Flux<ReceiverRecord<K, V>> receive();
+    Flux<ReceiverRecord<K, V>> receive(Integer prefetch);
+
+    default Flux<ReceiverRecord<K, V>> receive() {
+        return receive(null);
+    }
 
     /**
      * Returns a {@link Flux} containing each batch of consumer records returned by {@link Consumer#poll(long)}.
@@ -86,9 +91,14 @@ public interface KafkaReceiver<K, V> {
      * are committed periodically based on the configured commit interval and commit batch size of
      * this receiver's {@link ReceiverOptions}.
      *
+     * @param prefetch amount of prefetched batches
      * @return Flux of consumer record batches from Kafka that are auto-acknowledged
      */
-    Flux<Flux<ConsumerRecord<K, V>>> receiveAutoAck();
+    Flux<Flux<ConsumerRecord<K, V>>> receiveAutoAck(Integer prefetch);
+
+    default Flux<Flux<ConsumerRecord<K, V>>> receiveAutoAck() {
+        return receiveAutoAck(null);
+    }
 
     /**
      * Returns a {@link Flux} of consumer records that are committed before the record is dispatched
@@ -101,9 +111,14 @@ public interface KafkaReceiver<K, V> {
      * configuring {@link ReceiverOptions#atmostOnceCommitAheadSize()}. The maximum number of records that
      * may be lost on each partition if the consuming application crashes is <code>commitAheadSize + 1</code>.
      *
+     * @param prefetch amount of prefetched batches
      * @return Flux of consumer records whose offsets have been committed prior to dispatch
      */
-    Flux<ConsumerRecord<K, V>> receiveAtmostOnce();
+    Flux<ConsumerRecord<K, V>> receiveAtmostOnce(Integer prefetch);
+
+    default Flux<ConsumerRecord<K, V>> receiveAtmostOnce() {
+        return receiveAtmostOnce(null);
+    }
 
     /**
      * Returns a {@link Flux} of consumer record batches that may be used for exactly once

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
@@ -115,8 +115,8 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
     }
 
     void onRequest(long toAdd) {
+        log.debug("Requesting {} batches", toAdd);
         Operators.addCap(REQUESTED, this, toAdd);
-        log.debug("Scheduling next batch");
         pollEvent.schedule();
     }
 

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
@@ -116,6 +116,7 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
 
     void onRequest(long toAdd) {
         Operators.addCap(REQUESTED, this, toAdd);
+        log.debug("Scheduling next batch");
         pollEvent.schedule();
     }
 

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
@@ -12,6 +12,7 @@ import reactor.core.scheduler.Scheduler;
 import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.receiver.ReceiverOffset;
 import reactor.kafka.receiver.ReceiverOptions;
+import reactor.util.concurrent.Queues;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -61,7 +62,8 @@ class ConsumerHandler<K, V> {
 
     private final ConsumerEventLoop<K, V> consumerEventLoop;
 
-    private final Sinks.Many<ConsumerRecords<K, V>> sink = Sinks.many().unicast().onBackpressureBuffer();
+    private final Sinks.Many<ConsumerRecords<K, V>> sink =
+        Sinks.many().unicast().onBackpressureBuffer(Queues.<ConsumerRecords<K, V>>get(1).get());
 
     private Consumer<K, V> consumerProxy;
 

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
@@ -12,7 +12,6 @@ import reactor.core.scheduler.Scheduler;
 import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.receiver.ReceiverOffset;
 import reactor.kafka.receiver.ReceiverOptions;
-import reactor.util.concurrent.Queues;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -63,7 +62,7 @@ class ConsumerHandler<K, V> {
     private final ConsumerEventLoop<K, V> consumerEventLoop;
 
     private final Sinks.Many<ConsumerRecords<K, V>> sink =
-        Sinks.many().unicast().onBackpressureBuffer(Queues.<ConsumerRecords<K, V>>get(1).get());
+        Sinks.many().unicast().onBackpressureBuffer();
 
     private Consumer<K, V> consumerProxy;
 

--- a/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
@@ -51,7 +51,7 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V> {
         return withHandler(AckMode.MANUAL_ACK, (scheduler, handler) -> {
             return handler
                 .receive()
-                .publishOn(scheduler)
+                .publishOn(scheduler, 1)
                 .flatMapIterable(it -> it)
                 .map(record -> new ReceiverRecord<>(
                     record,
@@ -66,7 +66,7 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V> {
             return handler
                 .receive()
                 .filter(it -> !it.isEmpty())
-                .publishOn(scheduler)
+                .publishOn(scheduler, 1)
                 .map(consumerRecords -> {
                     return Flux.fromIterable(consumerRecords)
                         .doAfterTerminate(() -> {
@@ -87,8 +87,8 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V> {
                     return Flux
                         .fromIterable(records)
                         .concatMap(r -> handler.commit(r).thenReturn(r))
-                        .publishOn(scheduler);
-                });
+                        .publishOn(scheduler, 1);
+                }, 1);
         });
     }
 


### PR DESCRIPTION
This patch aims to improve memory usage with tweaking some defaults and and implementing few optimization. Key points:

- All `prefetch` parameters for `publishOn`s in `receive*` methods are set to 1 by default, and configurable via new overloadings
- ConsumerEventLoop is optimized based on discussion [here](https://github.com/reactor/reactor-kafka/issues/183) and #199

This PR will work better with #199, but can be merged separately.

fixes #183 