### PR TITLE
GitHub Actions Release Process: signing, artifactory, sonatype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: CI
-
 on:
     pull_request: {}
-    push:
-      branches:
-        - master
-        - "[0-9].[0-9]+.x"
-
 jobs:
   build:
     name: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,109 @@
+name: publish
+on:
+  push:
+    branches: # For branches, better to list them explicitly than regexp include
+      - master
+      - 1.2.x
+jobs:
+  # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push
+  # We specify the ubuntu version to minimize the chances we have to deal with a migration during a release
+  prepare:
+    # Notes on prepare: this job has no access to secrets, only github token. As a result, all non-core actions are centralized here
+    # This includes the tagging and drafting of release notes. Still, when possible we favor plain run of gradle tasks
+    name: prepare
+    runs-on: ubuntu-20.04
+    outputs:
+      versionType: ${{ steps.version.outputs.versionType }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: interpret version
+        id: version
+        #we only run the qualifyVersionGha task so that no other console printing can hijack this step's output
+        #output: versionType, fullVersion
+        #fails if versionType is BAD, which interrupts the workflow
+        run: ./gradlew qualifyVersionGha
+      - name: run checks
+        id: checks
+        run: ./gradlew check
+
+  #deploy the snapshot artifacts to Artifactory
+  deploySnapshot:
+    name: deploySnapshot
+    runs-on: ubuntu-20.04
+    needs: prepare
+    if: needs.prepare.outputs.versionType == 'SNAPSHOT'
+    environment: snapshots
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: deploy
+        env:
+          ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_SNAPSHOT_USERNAME}}
+          ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
+        run: |
+          ./gradlew assemble artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-snapshot-local
+
+  #sign the milestone artifacts and deploy them to Artifactory
+  deployMilestone:
+    name: deployMilestone
+    runs-on: ubuntu-20.04
+    needs: prepare
+    if: needs.prepare.outputs.versionType == 'MILESTONE'
+    environment: releases
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: deploy
+        env:
+          ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_USERNAME}}
+          ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
+          ORG_GRADLE_PROJECT_signingKey: ${{secrets.SIGNING_KEY}}
+          ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
+        run: |
+          ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-milestone-local
+      - name: tag
+        run: |
+          git config --local user.name 'reactorbot'
+          git config --local user.email '32325210+reactorbot@users.noreply.github.com'
+          git tag -m "Release milestone ${{ needs.prepare.outputs.fullVersion }}" v${{ needs.prepare.outputs.fullVersion }} ${{ github.sha }}
+          git push --tags
+
+  #sign the release artifacts and deploy them to Artifactory
+  deployRelease:
+    name: deployRelease
+    runs-on: ubuntu-20.04
+    needs: prepare
+    if: needs.prepare.outputs.versionType == 'RELEASE'
+    environment: releases
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: deploy
+        env:
+          ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_USERNAME}}
+          ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
+          ORG_GRADLE_PROJECT_signingKey: ${{secrets.SIGNING_KEY}}
+          ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{secrets.SONATYPE_USERNAME}}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{secrets.SONATYPE_PASSWORD}}
+        run: |
+          ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io  -Partifactory_publish_repoKey=libs-release-local publishMavenJavaPublicationToSonatypeRepository
+      - name: tag
+        run: |
+          git config --local user.name 'reactorbot'
+          git config --local user.email '32325210+reactorbot@users.noreply.github.com'
+          git tag -m "Release version ${{ needs.prepare.outputs.fullVersion }}" v${{ needs.prepare.outputs.fullVersion }} ${{ github.sha }}
+          git push --tags
+
+# For Gradle configuration of signing, see https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
+# publishMavenJavaPublicationToSonatypeRepository only sends to a staging repository

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -81,9 +81,9 @@ String getOrGenerateBuildNumber() {
 	if (project.hasProperty("buildNumber")) {
 		return project.findProperty("buildNumber")
 	}
-	def jenkinsNumber = System.getenv("BUILD_NUMBER")
-	if (jenkinsNumber != null) {
-		return jenkinsNumber
+	def ciNumber = System.getenv("GITHUB_RUN_NUMBER")
+	if (ciNumber != null) {
+		return ciNumber
 	}
 	ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC)
 	long secondsInDay = now.toEpochSecond() - ZonedDateTime.now(ZoneOffset.UTC).withSecond(0).withHour(0).withMinute(0).toEpochSecond()
@@ -112,8 +112,12 @@ if (project.hasProperty("artifactory_publish_password")) {
 				}
 			}
 			clientConfig.setIncludeEnvVars(false)
-			clientConfig.info.setBuildName('Reactor - Releaser - Kafka')
+			clientConfig.info.setBuildName('Reactor - Kafka')
 			clientConfig.info.setBuildNumber(buildNumber)
+			if (System.getenv("GITHUB_ACTIONS") == "true") {
+				clientConfig.info.setBuildUrl(System.getenv("GITHUB_SERVER_URL") + "/" + System.getenv("GITHUB_REPOSITORY") + "/actions/runs/" + System.getenv("GITHUB_RUN_ID"))
+				clientConfig.info.setVcsRevision(System.getenv("GITHUB_SHA"))
+			}
 		}
 	}
 }

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -14,8 +14,23 @@
  * limitations under the License.
  */
 
+import org.gradle.util.VersionNumber
+
+static def qualifyVersion(String v) {
+    def versionNumber = VersionNumber.parse(v)
+
+    if (versionNumber == VersionNumber.UNKNOWN) return "BAD";
+
+    if (versionNumber.qualifier == null || versionNumber.qualifier.size() == 0) return "RELEASE" //new scheme
+    if (versionNumber.qualifier == "RELEASE") return "RELEASE" //old scheme
+    if (versionNumber.qualifier.matches("(?:M|RC)\\d+")) return "MILESTONE"
+    if (versionNumber.qualifier == "SNAPSHOT" || versionNumber.qualifier == "BUILD-SNAPSHOT") return "SNAPSHOT"
+
+    return "BAD"
+}
+
 apply plugin: 'maven-publish'
-apply plugin: 'com.jfrog.artifactory'
+//we also conditionally apply artifactory and signing plugins below
 
 jar {
     manifest.attributes["Created-By"] = "${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
@@ -36,13 +51,42 @@ task javadocJar(type: Jar) {
     from '../NOTICE'
 }
 
+task qualifyVersionGha() {
+    doLast {
+        def versionType = qualifyVersion("$version")
+
+        println "::set-output name=versionType::$versionType"
+        println "::set-output name=fullVersion::$version"
+        if (versionType == "BAD") {
+            println "::error ::Unable to parse $version to a VersionNumber with recognizable qualifier"
+            throw new TaskExecutionException(tasks.getByName("qualifyVersionGha"), new IllegalArgumentException("Unable to parse $version to a VersionNumber with recognizable qualifier"))
+        }
+    }
+}
+
 publishing {
+    repositories {
+        maven {
+            name = "mock"
+            url = "${rootProject.buildDir}/repo"
+        }
+        if (qualifyVersion("$version") == "RELEASE") {
+            maven {
+                name = "sonatype"
+                url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
+                credentials {
+                    username findProperty("sonatypeUsername")
+                    password findProperty("sonatypePassword")
+                }
+            }
+        }
+    }
+
     publications {
         mavenJava(MavenPublication) {
             from components.java
             artifact sourcesJar
             artifact javadocJar
-            //other project-specific artifacts are added to publication in each project's specific configuration
 
             pom {
                 afterEvaluate {
@@ -70,14 +114,19 @@ publishing {
                 }
                 developers {
                     developer {
-                        id = 'rsivaram'
-                        name = 'Rajini Sivaram'
-                        email = 'rsivaram@pivotal.io'
+                        id = 'simonbasle'
+                        name = 'Simon Baslé'
+                        email = 'sbasle@vmware.com'
                     }
                     developer {
                         id = 'OlegDokuka'
                         name = 'Oleh Dokuka'
-                        email = 'oleh.dokuka@icloud.com'
+                        email = 'odokuka@vmware.com'
+                    }
+                    developer {
+                        id = 'garyrussell'
+                        name = 'Gary Russell'
+                        email = 'grussell@vmware.com'
                     }
                 }
                 issueManagement {
@@ -98,8 +147,27 @@ publishing {
     }
 }
 
-artifactoryPublish {
-    //don't activate the onlyIf clause below yet, so that Bamboo builds will publish stuff...
-    //onlyIf { project.hasProperty("artifactory_publish_password") }
-    publications(publishing.publications.mavenJava)
+if (rootProject.hasProperty("artifactory_publish_password")) {
+    apply plugin: "com.jfrog.artifactory"
+
+    artifactoryPublish {
+        publications(publishing.publications.mavenJava)
+    }
+}
+
+if (qualifyVersion("$version") in ["RELEASE", "MILESTONE"] || rootProject.hasProperty("forceSigning")) {
+    apply plugin: 'signing'
+
+    signing {
+        //requiring signature if there is a publish task that is not to MavenLocal
+        required {  gradle.taskGraph.allTasks.any { it.name.toLowerCase().contains("publish")	&& !it.name.contains("MavenLocal") } }
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+
+        useInMemoryPgpKeys(signingKey, signingPassword)
+
+        afterEvaluate {
+            sign publishing.publications.mavenJava
+        }
+    }
 }


### PR DESCRIPTION
This commit changes the release process to be based on GitHub Actions.

CI is already performed on GHA, but that workflow will now only run
for pull_request trigger.

We define helper tasks and methods in the releaser.gradle file to help
interpret the version number. The trigger is pushing a commit to an
active maintenance branch.

The new workflow uses GitHub Environments to manage access to secrets,
especially in the case of milestones and releases as it introduces
signing of artifacts in these cases. It is split into 4 jobs, 3 of
which are conditional and depend on a GitHub Environment.

Notably:
- Add a function to qualify a version number as one of RELEASE,
MILESTONE, SNAPSHOT or BAD
- Add a GitHub Actions oriented task, `qualifyVersionGha`, which
produces gha step output for the current project version. `versionType`
is an application of the above function and `fullVersion` is the plain
project's `version`
- tag releases and milestones using `git` commands in their respective
jobs
- Activate the JFrog Artifactory plugin only if a password is defined
(including in subprojects)
- Add the `signing` plugin, activated only if a signing key is defined,
requiring that signing be performed if a publish task is invoked other
than mavenLocal (can be forced with `-PforceSigning`)
- Add a Maven publication repository if Sonatype OSS credentials are
defined, plus a local `mock` repository for debugging of build
- cleaned up the developers list in the pom.xml

See reactor/reactor#694.
