### PR TITLE
Renamed branch master to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: publish
 on:
   push:
     branches: # For branches, better to list them explicitly than regexp include
-      - master
+      - main
       - 1.2.x
 jobs:
   # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push

--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -108,7 +108,7 @@ sender.send(outboundFlux)                          // <1>
 <4> Subscribe to trigger the actual flow of records from `outboundFlux` to Kafka.
 
 
-See https://github.com/reactor/reactor-kafka/blob/master/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleProducer.java  for the full code listing of a sample producer.
+See https://github.com/reactor/reactor-kafka/blob/main/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleProducer.java  for the full code listing of a sample producer.
 
 ==== Error handling
 

--- a/src/docs/asciidoc/examples.adoc
+++ b/src/docs/asciidoc/examples.adoc
@@ -2,7 +2,7 @@
 
 This section shows sample code segments for typical scenarios where Reactor Kafka API
 may be used. Full code listing for these scenarios are included in the
-https://github.com/reactor/reactor-kafka/tree/master/reactor-kafka-samples[samples sub-project].
+https://github.com/reactor/reactor-kafka/tree/main/reactor-kafka-samples[samples sub-project].
 
 [[sample-producer]]
 === Sending records to Kafka

--- a/src/docs/asciidoc/getting-started.adoc
+++ b/src/docs/asciidoc/getting-started.adoc
@@ -80,7 +80,7 @@ Set `CLASSPATH` for running reactor-kafka samples. `CLASSPATH` can be obtained u
 
 ===== Sample Producer
 
-See https://github.com/reactor/reactor-kafka/blob/master/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleProducer.java for sample producer code.
+See https://github.com/reactor/reactor-kafka/blob/main/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleProducer.java for sample producer code.
 
 Run sample producer:
 
@@ -117,7 +117,7 @@ correlation metadata to match each result to its corresponding message.
 
 ===== Sample Consumer
 
-See https://github.com/reactor/reactor-kafka/blob/master/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleConsumer.java for sample consumer code.
+See https://github.com/reactor/reactor-kafka/blob/main/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleConsumer.java for sample consumer code.
 
 Run sample consumer:
 


### PR DESCRIPTION
This is in preparation of renaming master to main.
Targeting 1.2.x to align documentation and build on both maintened branches.﻿