### PR TITLE
GH-215: Fix Blocking Calls on Sender Thread

### DIFF
--- a/src/test/java/reactor/kafka/mock/MockProducer.java
+++ b/src/test/java/reactor/kafka/mock/MockProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -266,7 +266,7 @@ public class MockProducer implements Producer<Integer, String> {
     private void verifyTransactionsInitialized() {
         String transactionId = senderOptions.transactionalId();
         String thread = Thread.currentThread().getName();
-        assertTrue("Transactional operation on wrong thread " + thread, thread.contains(transactionId));
+        assertTrue("Transactional operation on wrong thread " + thread, thread.contains("reactor-kafka-sender"));
         if (!this.transactionInitialized)
             throw new IllegalStateException("MockProducer hasn't been initialized for transactions.");
     }


### PR DESCRIPTION
Resolves https://github.com/reactor/reactor-kafka/issues/215

The `KafkaSender` has 2 schedulers, one that allows blocking (for send and close)
and one for publishing send results, which does not allow blocking.

Kafka `Producer` `initTransactions`, `commitTransaction` and `abortTransaction`
methods are blocking calls; they were incorrectly called on the second thread, as
detected by `BlockHound`. They should be called on the thread that allows blocking.

Furthermore, `beginTransaction()`, `send()`, `commitTransaction()` must be called in
sequence so `beginTransation()` is also moved to that same thread.

While testing this change, one test that uses `sink.asFlux` to publish records to
send failed. This is because the ultimate subscription to that flux is async and
was not completed before the `sink.emitNext()` calls.

The resolution was to retain the existing behavior of using the default immediate
scheduler (from `SenderOptions`) for non-transactional producers.

Added another test to reproduce the problem with a transactional producer, but adding
logic to wait for the `sinkAsFlux` to be subscribed before emitting test records.