### PR TITLE
[chores] Copyright switch Pivotal to VMware, polish headers

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Reactor Kafka
-Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
 
 Copyright 2016-2018 The Apache Software Foundation.
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -1,7 +1,3 @@
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
-import java.time.temporal.ChronoField
-
 /*
  * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
@@ -9,7 +5,7 @@ import java.time.temporal.ChronoField
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,6 +14,9 @@ import java.time.temporal.ChronoField
  * limitations under the License.
  */
 
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoField
 
 if (rootProject.hasProperty("releaserDryRun") && rootProject.findProperty("releaserDryRun") != "false") {
 	println "Adding MavenLocal() for benefit of releaser dry run"

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -3,7 +3,7 @@ import java.time.ZonedDateTime
 import java.time.temporal.ChronoField
 
 /*
- * Copyright (c) 2011-Present Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleConsumer.java
+++ b/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleConsumer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.samples;
 
 import java.text.SimpleDateFormat;

--- a/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleConsumer.java
+++ b/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleProducer.java
+++ b/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleProducer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.samples;
 
 import java.text.SimpleDateFormat;

--- a/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleProducer.java
+++ b/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleScenarios.java
+++ b/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleScenarios.java
+++ b/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleScenarios.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.samples;
 
 import java.nio.ByteBuffer;

--- a/reactor-kafka-samples/src/test/java/reactor/kafka/samples/SampleScenariosTest.java
+++ b/reactor-kafka-samples/src/test/java/reactor/kafka/samples/SampleScenariosTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-samples/src/test/java/reactor/kafka/samples/SampleScenariosTest.java
+++ b/reactor-kafka-samples/src/test/java/reactor/kafka/samples/SampleScenariosTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.samples;
 
 import java.time.Duration;

--- a/reactor-kafka-samples/src/test/java/reactor/kafka/samples/SampleTest.java
+++ b/reactor-kafka-samples/src/test/java/reactor/kafka/samples/SampleTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.samples;
 
 import java.util.concurrent.CountDownLatch;

--- a/reactor-kafka-samples/src/test/java/reactor/kafka/samples/SampleTest.java
+++ b/reactor-kafka-samples/src/test/java/reactor/kafka/samples/SampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-samples/src/test/resources/log4j.properties
+++ b/reactor-kafka-samples/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 Pivotal Software Inc, All Rights Reserved.
+# Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ConsumerPerformance.java
+++ b/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ConsumerPerformance.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *    https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,7 +21,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,6 +29,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.tools.perf;
 
 import static net.sourceforge.argparse4j.impl.Arguments.store;

--- a/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ConsumerPerformance.java
+++ b/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ConsumerPerformance.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/EndToEndLatency.java
+++ b/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/EndToEndLatency.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *    https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,7 +21,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,6 +29,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.tools.perf;
 
 import static net.sourceforge.argparse4j.impl.Arguments.store;

--- a/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/EndToEndLatency.java
+++ b/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/EndToEndLatency.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ProducerPerformance.java
+++ b/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ProducerPerformance.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *    https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,7 +21,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,6 +29,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.tools.perf;
 
 import static net.sourceforge.argparse4j.impl.Arguments.store;

--- a/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ProducerPerformance.java
+++ b/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ProducerPerformance.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ThroughputThrottler.java
+++ b/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ThroughputThrottler.java
@@ -6,7 +6,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *    https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,7 +21,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,6 +29,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.tools.perf;
 
 

--- a/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ThroughputThrottler.java
+++ b/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ThroughputThrottler.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-tools/src/test/java/reactor/kafka/tools/perf/ConsumerPerformanceTest.java
+++ b/reactor-kafka-tools/src/test/java/reactor/kafka/tools/perf/ConsumerPerformanceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.tools.perf;
 
 import java.util.Map;

--- a/reactor-kafka-tools/src/test/java/reactor/kafka/tools/perf/ConsumerPerformanceTest.java
+++ b/reactor-kafka-tools/src/test/java/reactor/kafka/tools/perf/ConsumerPerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-tools/src/test/java/reactor/kafka/tools/perf/EndToEndLatencyTest.java
+++ b/reactor-kafka-tools/src/test/java/reactor/kafka/tools/perf/EndToEndLatencyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.tools.perf;
 
 import java.util.Map;

--- a/reactor-kafka-tools/src/test/java/reactor/kafka/tools/perf/EndToEndLatencyTest.java
+++ b/reactor-kafka-tools/src/test/java/reactor/kafka/tools/perf/EndToEndLatencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-tools/src/test/java/reactor/kafka/tools/perf/ProducerPerformanceTest.java
+++ b/reactor-kafka-tools/src/test/java/reactor/kafka/tools/perf/ProducerPerformanceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.tools.perf;
 
 import java.util.Map;

--- a/reactor-kafka-tools/src/test/java/reactor/kafka/tools/perf/ProducerPerformanceTest.java
+++ b/reactor-kafka-tools/src/test/java/reactor/kafka/tools/perf/ProducerPerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-tools/src/test/java/reactor/kafka/tools/util/PerfTestUtils.java
+++ b/reactor-kafka-tools/src/test/java/reactor/kafka/tools/util/PerfTestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.tools.util;
 
 import java.util.HashMap;

--- a/reactor-kafka-tools/src/test/java/reactor/kafka/tools/util/PerfTestUtils.java
+++ b/reactor-kafka-tools/src/test/java/reactor/kafka/tools/util/PerfTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver;
 
 import java.time.Duration;

--- a/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver;
 
 import java.util.function.Function;

--- a/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/MutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/MutableReceiverOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/MutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/MutableReceiverOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver;
 
 import java.time.Duration;

--- a/src/main/java/reactor/kafka/receiver/ReceiverOffset.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverOffset.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver;
 
 import org.apache.kafka.clients.consumer.RetriableCommitFailedException;

--- a/src/main/java/reactor/kafka/receiver/ReceiverOffset.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/ReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverOptions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.kafka.receiver;
 
 import java.time.Duration;

--- a/src/main/java/reactor/kafka/receiver/ReceiverPartition.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverPartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/ReceiverPartition.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverPartition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver;
 
 import org.apache.kafka.common.TopicPartition;

--- a/src/main/java/reactor/kafka/receiver/ReceiverRecord.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverRecord.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/src/main/java/reactor/kafka/receiver/ReceiverRecord.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/internals/CommittableBatch.java
+++ b/src/main/java/reactor/kafka/receiver/internals/CommittableBatch.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver.internals;
 
 import java.util.ArrayList;

--- a/src/main/java/reactor/kafka/receiver/internals/CommittableBatch.java
+++ b/src/main/java/reactor/kafka/receiver/internals/CommittableBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerFactory.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver.internals;
 
 import org.apache.kafka.clients.consumer.Consumer;

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerFactory.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver.internals;
 
 import java.lang.reflect.InvocationHandler;

--- a/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/internals/KafkaSchedulers.java
+++ b/src/main/java/reactor/kafka/receiver/internals/KafkaSchedulers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/internals/KafkaSchedulers.java
+++ b/src/main/java/reactor/kafka/receiver/internals/KafkaSchedulers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver.internals;
 
 import java.util.concurrent.ThreadFactory;

--- a/src/main/java/reactor/kafka/receiver/internals/OperatorUtils.java
+++ b/src/main/java/reactor/kafka/receiver/internals/OperatorUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.kafka.receiver.internals;
 
 import java.util.concurrent.atomic.AtomicLong;

--- a/src/main/java/reactor/kafka/receiver/internals/SeekablePartition.java
+++ b/src/main/java/reactor/kafka/receiver/internals/SeekablePartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/internals/SeekablePartition.java
+++ b/src/main/java/reactor/kafka/receiver/internals/SeekablePartition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver.internals;
 
 import java.util.Collections;

--- a/src/main/java/reactor/kafka/receiver/package-info.java
+++ b/src/main/java/reactor/kafka/receiver/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/receiver/package-info.java
+++ b/src/main/java/reactor/kafka/receiver/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,4 +17,5 @@
 /**
  * Reactor Kafka Receiver API
  */
+
 package reactor.kafka.receiver;

--- a/src/main/java/reactor/kafka/sender/ImmutableSenderOptions.java
+++ b/src/main/java/reactor/kafka/sender/ImmutableSenderOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/ImmutableSenderOptions.java
+++ b/src/main/java/reactor/kafka/sender/ImmutableSenderOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender;
 
 import java.time.Duration;

--- a/src/main/java/reactor/kafka/sender/ImmutableSenderOptions.java
+++ b/src/main/java/reactor/kafka/sender/ImmutableSenderOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/KafkaOutbound.java
+++ b/src/main/java/reactor/kafka/sender/KafkaOutbound.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender;
 
 import org.apache.kafka.clients.producer.ProducerConfig;

--- a/src/main/java/reactor/kafka/sender/KafkaOutbound.java
+++ b/src/main/java/reactor/kafka/sender/KafkaOutbound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/KafkaSender.java
+++ b/src/main/java/reactor/kafka/sender/KafkaSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/KafkaSender.java
+++ b/src/main/java/reactor/kafka/sender/KafkaSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender;
 
 import java.util.Map;

--- a/src/main/java/reactor/kafka/sender/MutableSenderOptions.java
+++ b/src/main/java/reactor/kafka/sender/MutableSenderOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/MutableSenderOptions.java
+++ b/src/main/java/reactor/kafka/sender/MutableSenderOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender;
 
 import java.time.Duration;

--- a/src/main/java/reactor/kafka/sender/MutableSenderOptions.java
+++ b/src/main/java/reactor/kafka/sender/MutableSenderOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/SenderOptions.java
+++ b/src/main/java/reactor/kafka/sender/SenderOptions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.kafka.sender;
 
 import java.time.Duration;

--- a/src/main/java/reactor/kafka/sender/SenderRecord.java
+++ b/src/main/java/reactor/kafka/sender/SenderRecord.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender;
 
 import org.apache.kafka.clients.producer.ProducerRecord;

--- a/src/main/java/reactor/kafka/sender/SenderRecord.java
+++ b/src/main/java/reactor/kafka/sender/SenderRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/SenderResult.java
+++ b/src/main/java/reactor/kafka/sender/SenderResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/SenderResult.java
+++ b/src/main/java/reactor/kafka/sender/SenderResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender;
 
 import org.apache.kafka.clients.producer.Producer;

--- a/src/main/java/reactor/kafka/sender/TransactionManager.java
+++ b/src/main/java/reactor/kafka/sender/TransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/TransactionManager.java
+++ b/src/main/java/reactor/kafka/sender/TransactionManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender;
 
 import java.util.Map;

--- a/src/main/java/reactor/kafka/sender/internals/DefaultKafkaSender.java
+++ b/src/main/java/reactor/kafka/sender/internals/DefaultKafkaSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender.internals;
 
 import java.lang.reflect.InvocationHandler;

--- a/src/main/java/reactor/kafka/sender/internals/DefaultKafkaSender.java
+++ b/src/main/java/reactor/kafka/sender/internals/DefaultKafkaSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/internals/ProducerFactory.java
+++ b/src/main/java/reactor/kafka/sender/internals/ProducerFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender.internals;
 
 import org.apache.kafka.clients.producer.KafkaProducer;

--- a/src/main/java/reactor/kafka/sender/internals/ProducerFactory.java
+++ b/src/main/java/reactor/kafka/sender/internals/ProducerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/package-info.java
+++ b/src/main/java/reactor/kafka/sender/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/package-info.java
+++ b/src/main/java/reactor/kafka/sender/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,4 +17,5 @@
 /**
  * Reactor Kafka Sender API
  */
+
 package reactor.kafka.sender;

--- a/src/test/java/reactor/kafka/AbstractKafkaTest.java
+++ b/src/test/java/reactor/kafka/AbstractKafkaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/AbstractKafkaTest.java
+++ b/src/test/java/reactor/kafka/AbstractKafkaTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka;
 
 import java.time.Duration;

--- a/src/test/java/reactor/kafka/cluster/EmbeddedKafkaCluster.java
+++ b/src/test/java/reactor/kafka/cluster/EmbeddedKafkaCluster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.cluster;
 
 import java.io.IOException;

--- a/src/test/java/reactor/kafka/cluster/EmbeddedKafkaCluster.java
+++ b/src/test/java/reactor/kafka/cluster/EmbeddedKafkaCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/mock/Message.java
+++ b/src/test/java/reactor/kafka/mock/Message.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.mock;
 
 public class Message {

--- a/src/test/java/reactor/kafka/mock/Message.java
+++ b/src/test/java/reactor/kafka/mock/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/mock/MockCluster.java
+++ b/src/test/java/reactor/kafka/mock/MockCluster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.mock;
 
 import java.util.ArrayList;

--- a/src/test/java/reactor/kafka/mock/MockCluster.java
+++ b/src/test/java/reactor/kafka/mock/MockCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/mock/MockConsumer.java
+++ b/src/test/java/reactor/kafka/mock/MockConsumer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.mock;
 
 import java.time.Duration;

--- a/src/test/java/reactor/kafka/mock/MockConsumer.java
+++ b/src/test/java/reactor/kafka/mock/MockConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/mock/MockProducer.java
+++ b/src/test/java/reactor/kafka/mock/MockProducer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.mock;
 
 import java.util.ArrayList;

--- a/src/test/java/reactor/kafka/mock/MockProducer.java
+++ b/src/test/java/reactor/kafka/mock/MockProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver;
 
 import java.time.Duration;

--- a/src/test/java/reactor/kafka/receiver/ReceiverOptionsTest.java
+++ b/src/test/java/reactor/kafka/receiver/ReceiverOptionsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver;
 
 import java.util.HashMap;

--- a/src/test/java/reactor/kafka/receiver/ReceiverOptionsTest.java
+++ b/src/test/java/reactor/kafka/receiver/ReceiverOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/receiver/internals/KafkaSchedulersTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/KafkaSchedulersTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver.internals;
 
 import java.util.concurrent.CountDownLatch;

--- a/src/test/java/reactor/kafka/receiver/internals/KafkaSchedulersTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/KafkaSchedulersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver.internals;
 
 import java.lang.reflect.Field;

--- a/src/test/java/reactor/kafka/receiver/internals/OperatorUtilsTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/OperatorUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.kafka.receiver.internals;
 
 import java.util.Arrays;

--- a/src/test/java/reactor/kafka/receiver/internals/TestableReceiver.java
+++ b/src/test/java/reactor/kafka/receiver/internals/TestableReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/receiver/internals/TestableReceiver.java
+++ b/src/test/java/reactor/kafka/receiver/internals/TestableReceiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.receiver.internals;
 
 import java.time.Duration;

--- a/src/test/java/reactor/kafka/sender/KafkaSenderTest.java
+++ b/src/test/java/reactor/kafka/sender/KafkaSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/sender/KafkaSenderTest.java
+++ b/src/test/java/reactor/kafka/sender/KafkaSenderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender;
 
 import java.time.Duration;

--- a/src/test/java/reactor/kafka/sender/SenderOptionsTest.java
+++ b/src/test/java/reactor/kafka/sender/SenderOptionsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender;
 
 import org.junit.Test;

--- a/src/test/java/reactor/kafka/sender/SenderOptionsTest.java
+++ b/src/test/java/reactor/kafka/sender/SenderOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/sender/SenderOptionsTest.java
+++ b/src/test/java/reactor/kafka/sender/SenderOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/sender/internals/MockSenderTest.java
+++ b/src/test/java/reactor/kafka/sender/internals/MockSenderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender.internals;
 
 

--- a/src/test/java/reactor/kafka/sender/internals/MockSenderTest.java
+++ b/src/test/java/reactor/kafka/sender/internals/MockSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/sender/internals/MockTransactionTest.java
+++ b/src/test/java/reactor/kafka/sender/internals/MockTransactionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.sender.internals;
 
 import java.time.Duration;

--- a/src/test/java/reactor/kafka/sender/internals/MockTransactionTest.java
+++ b/src/test/java/reactor/kafka/sender/internals/MockTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/util/TestUtils.java
+++ b/src/test/java/reactor/kafka/util/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       https://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package reactor.kafka.util;
 
 import java.time.Duration;

--- a/src/test/java/reactor/kafka/util/TestUtils.java
+++ b/src/test/java/reactor/kafka/util/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018 Pivotal Software Inc, All Rights Reserved.
+# Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION

 - copyright header to VMware instead of Pivotal
 - update the pom content (emails, org)
 - in copyright headers, have date range harmonized on 2016-2021
 - polish copyright header: url indentation, blank line after license

See reactor/reactor#682.