### PR TITLE
GH-215: Remove Invalid Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,12 @@ jobs:
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true
         configuration-cache-enabled: true
+    - name: Capture Test Results
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-results
+        path: |
+          'build/reports/tests/**/*.*'
+          '*/build/reports/tests/**/*.*'
+        retention-days: 3


### PR DESCRIPTION
GH-215 added this test, but it is invalid because `stopOnError(false)` makes no
sense for a transactional send, since the transaction will be rolled back anyway.
If this occurs before the record is actually sent, no record is available at the
consumer (which is not transactional anyway so it can "see" uncommitted records
(which is why it worked most of the time).

Remove the test; the same PR added verification that the blocking calls were made
on the correct thread.

Also add failed test artifact upload for PR builds.