### PR TITLE
kafka-clients 3.0.0 Compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,6 @@ ext {
   slf4jVersion = '1.7.30'
   log4jVersion = '2.13.3'
   junitVersion = '4.12'
-  zkVersion = "3.4.13"
   powermockVersion = '1.7.4'
   testcontainersVersion = '1.15.2'
 
@@ -80,6 +79,9 @@ configure(allprojects) { project ->
     if (version.endsWith('-SNAPSHOT')) {
       maven { url 'https://repo.spring.io/snapshot' }
     }
+
+//    maven { url 'https://repository.apache.org/content/groups/staging/' }
+
   }
 
   apply plugin: 'maven'
@@ -127,6 +129,7 @@ configure(allprojects) { project ->
     compileOnly "com.google.code.findbugs:jsr305:$googleJsr305Version"
     compile "org.apache.kafka:kafka-clients:$kafkaVersion"
     compile "io.projectreactor:reactor-core:$reactorCoreVersion"
+//    compile "org.slf4j:slf4j-api:$slf4jVersion"
 
     testCompileOnly "com.google.code.findbugs:jsr305:$googleJsr305Version"
     testCompile "junit:junit:$junitVersion"
@@ -134,10 +137,11 @@ configure(allprojects) { project ->
     testCompile "io.projectreactor:reactor-test:$reactorCoreVersion"
     testCompile "org.powermock:powermock-module-junit4:$powermockVersion"
     testCompile "org.powermock:powermock-core:$powermockVersion"
-    testCompile "org.powermock:powermock-api-mockito:$powermockVersion"
+    testCompile "org.powermock:powermock-api-mockito2:$powermockVersion"
     testCompile "org.apache.logging.log4j:log4j-api:$log4jVersion"
     testCompile "org.apache.logging.log4j:log4j-core:$log4jVersion"
     testCompile "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+    // move to compile for 3.0.0 clients
     testCompile "org.slf4j:slf4j-api:$slf4jVersion"
     testCompile "org.testcontainers:kafka:$testcontainersVersion"
     testCompile 'org.awaitility:awaitility:4.0.2'

--- a/src/test/java/reactor/kafka/mock/MockConsumer.java
+++ b/src/test/java/reactor/kafka/mock/MockConsumer.java
@@ -16,24 +16,6 @@
 
 package reactor.kafka.mock;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.ConcurrentModificationException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.regex.Pattern;
-
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -51,6 +33,24 @@ import org.apache.kafka.common.errors.InvalidOffsetException;
 import org.apache.kafka.common.record.TimestampType;
 import reactor.kafka.receiver.ReceiverOptions;
 import reactor.kafka.receiver.internals.ConsumerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
 
 /**
  * Mock consumer for testing. To enable testing with different Kafka versions, this class
@@ -411,7 +411,7 @@ public class MockConsumer extends org.apache.kafka.clients.consumer.MockConsumer
     }
 
     @Override
-    public void close() {
+    public void close() { // https://issues.apache.org/jira/browse/KAFKA-13262
         acquire();
         try {
             executor.shutdown();

--- a/src/test/java/reactor/kafka/mock/MockConsumer.java
+++ b/src/test/java/reactor/kafka/mock/MockConsumer.java
@@ -411,7 +411,7 @@ public class MockConsumer extends org.apache.kafka.clients.consumer.MockConsumer
     }
 
     @Override
-    public void close() { // https://issues.apache.org/jira/browse/KAFKA-13262
+    public void close() {
         acquire();
         try {
             executor.shutdown();

--- a/src/test/java/reactor/kafka/receiver/internals/ReceiverRecordTests.java
+++ b/src/test/java/reactor/kafka/receiver/internals/ReceiverRecordTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.kafka.receiver.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Test;
+import reactor.kafka.receiver.ReceiverRecord;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Gary Russell
+ * @since 1.3.6
+ *
+ */
+public class ReceiverRecordTests {
+
+    @SuppressWarnings({ "rawtypes", "unchecked", "deprecation" })
+    @Test
+    public void testChecksum() {
+        ConsumerRecord record = new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 42L,
+                0, 0, null, null);
+        ReceiverRecord rr = new ReceiverRecord<>(record, null);
+        assertEquals(42L, rr.checksum());
+    }
+
+}

--- a/src/test/java/reactor/kafka/util/ConsumerDelegateTests.java
+++ b/src/test/java/reactor/kafka/util/ConsumerDelegateTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.kafka.util;
+
+import org.junit.Test;
+
+/**
+ * @author Gary Russell
+ * @since 1.3.6
+ *
+ */
+public class ConsumerDelegateTests {
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void testLag() {
+//        Consumer delegate = mock(Consumer.class);
+//        ConsumerDelegate consumer = new ConsumerDelegate(delegate);
+//        given(delegate.currentLag(any())).willReturn(OptionalLong.of(42L));
+//        assertEquals(42L, consumer.currentLag(new TopicPartition("foo", 0)).getAsLong());
+    }
+
+}


### PR DESCRIPTION
The upcoming 3.0.0 release adds a new method to `Consumer` and removes
a deprecated one from `ConsumerRecord`.

Use reflection for these two methods to enable reactor-kafka to be used
with the older clients as well as 3.0.0 when used in other projects, such
as Spring for Apache Kafka.