### PR TITLE
Support Out of Order Commits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext {
   gradleScriptDir = "${rootProject.projectDir}/gradle"
 
   //reactor core version is now defined in gradle.properties
-  kafkaVersion = '2.6.1'
+  kafkaVersion = '2.8.1'
   scalaVersion = '2.11'
   metricsVersion = '2.2.0'
 

--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -390,6 +390,26 @@ Note that committing an offset acknowledges and commits all previous offsets on 
 acknowledged offsets are committed when partitions are revoked during rebalance and when the receive
 Flux is terminated.
 
+==== Out of Order Commits
+
+Starting with version 1.3.8, commits can be performed out of order and the framework will defer the commits as needed, until any "gaps" are filled.
+This removes the need for applications to keep track of offsets and commit them in the right order.
+Deferring commits increases the likelihood of duplicate deliveries if the application crashes while deferred commits are present.
+
+To enable this feature, set the `maxDeferredCommits` property of `ReceiverOptions`.
+If the number of deferred offset commits exceeds this value, the consumer is `pause()` d until the number of deferred commits is reduced by the application acknowledging or commiting some of the "missing" offsets.
+
+[source, java]
+----
+ReceiverOptions<Object, Object> options = ReceiverOptions.create()
+    .maxDeferredCommits(100)
+    .subscription(Collections.singletonList("someTopic"));
+----
+
+The number is an aggregate of deferred commits across all the assigned topics/partitions.
+
+Leaving the property at its default `0` disables the feature and commits are performed whenever called.
+
 ==== Auto-acknowledgement of batches of records
 
 `KafkaReceiver#receiveAutoAck` returns a `Flux` of batches of records returned by each `KafkaConsumer#poll()`.
@@ -513,5 +533,3 @@ underlying consumer is closed.
 
 Only one receive operation may be active in a `KafkaReceiver` at any one time. Any of the receive
 methods can be invoked after the receive Flux corresponding to the last receive is terminated.
-
-

--- a/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
@@ -55,6 +55,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
     private final int commitBatchSize;
     private final int atmostOnceCommitAheadSize;
     private final int maxCommitAttempts;
+    private final int maxDeferredCommits;
     private final Collection<String> subscribeTopics;
     private final Collection<TopicPartition> assignTopicPartitions;
     private final Pattern subscribePattern;
@@ -88,6 +89,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
         commitBatchSize = 0;
         atmostOnceCommitAheadSize = 0;
         maxCommitAttempts = DEFAULT_MAX_COMMIT_ATTEMPTS;
+        maxDeferredCommits = 0;
         subscribeTopics = null;
         assignTopicPartitions = null;
         subscribePattern = null;
@@ -107,6 +109,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
         int commitBatchSize,
         int atmostOnceCommitAheadSize,
         int maxCommitAttempts,
+        int maxDeferredCommits,
         Collection<String> topics,
         Collection<TopicPartition> partitions,
         Pattern pattern,
@@ -123,6 +126,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
         this.commitBatchSize = commitBatchSize;
         this.atmostOnceCommitAheadSize = atmostOnceCommitAheadSize;
         this.maxCommitAttempts = maxCommitAttempts;
+        this.maxDeferredCommits = maxDeferredCommits;
         this.subscribeTopics = topics == null ? null : new HashSet<>(topics);
         this.assignTopicPartitions = partitions == null ? null : new HashSet<>(partitions);
         this.subscribePattern = pattern;
@@ -159,6 +163,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
@@ -180,6 +185,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
@@ -206,6 +212,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
@@ -240,6 +247,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
@@ -269,6 +277,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
@@ -295,6 +304,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
@@ -321,6 +331,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
@@ -342,6 +353,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
@@ -363,6 +375,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
@@ -394,6 +407,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 Objects.requireNonNull(topics),
                 null,
                 null,
@@ -415,6 +429,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 null,
                 null,
                 Objects.requireNonNull(pattern),
@@ -436,6 +451,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 null,
                 Objects.requireNonNull(partitions),
                 null,
@@ -492,6 +508,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
@@ -521,6 +538,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
@@ -550,6 +568,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 commitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
@@ -579,10 +598,38 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier
+        );
+    }
+
+    @Override
+    public int maxDeferredCommits() {
+        return maxDeferredCommits;
+    }
+
+    @Override
+    public ReceiverOptions<K, V> maxDeferredCommits(int maxDeferred) {
+        return new ImmutableReceiverOptions<>(
+            properties,
+            assignListeners,
+            revokeListeners,
+            keyDeserializer,
+            valueDeserializer,
+            pollTimeout,
+            closeTimeout,
+            commitInterval,
+            commitBatchSize,
+            atmostOnceCommitAheadSize,
+            maxCommitAttempts,
+            maxDeferred,
+            subscribeTopics,
+            assignTopicPartitions,
+            subscribePattern,
+            schedulerSupplier
         );
     }
 
@@ -605,6 +652,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 commitBatchSize,
                 atmostOnceCommitAheadSize,
                 maxCommitAttempts,
+                maxDeferredCommits,
                 subscribeTopics,
                 assignTopicPartitions,
                 subscribePattern,

--- a/src/main/java/reactor/kafka/receiver/ReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverOptions.java
@@ -236,6 +236,17 @@ public interface ReceiverOptions<K, V> {
     ReceiverOptions<K, V> maxCommitAttempts(int maxAttempts);
 
     /**
+     * Set to greater than 0 to enable out of order commit sequencing. If the number of
+     * deferred commits exceeds this value, the consumer is paused until the deferred
+     * commits are reduced.
+     * @return options instance with updated number of max deferred commits.
+     * @since 1.3.8
+     */
+    default ReceiverOptions<K, V> maxDeferredCommits(int maxDeferred) {
+        return this;
+    }
+
+    /**
      * Configures the Supplier for a Scheduler on which Records will be published
      * @return options instance with updated publishing Scheduler Supplier
      */
@@ -370,6 +381,17 @@ public interface ReceiverOptions<K, V> {
      */
     @NonNull
     int maxCommitAttempts();
+
+    /**
+     * When greater than 0, enables out of order commit sequencing. If the number of
+     * deferred commits exceeds this value, the consumer is paused until the deferred
+     * commits are reduced.
+     * @return the maximum deferred commits.
+     * @since 1.3.8
+     */
+    default int maxDeferredCommits() {
+        return 0;
+    }
 
     /**
      * Returns the Supplier for a Scheduler that Records will be published on

--- a/src/main/java/reactor/kafka/receiver/internals/CommittableBatch.java
+++ b/src/main/java/reactor/kafka/receiver/internals/CommittableBatch.java
@@ -17,11 +17,14 @@
 package reactor.kafka.receiver.internals;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
@@ -30,12 +33,18 @@ import reactor.core.publisher.MonoSink;
 class CommittableBatch {
 
     final Map<TopicPartition, Long> consumedOffsets = new HashMap<>();
+    private final Map<TopicPartition, List<Long>> uncommitted = new HashMap<>();
+    private final Map<TopicPartition, List<Long>> deferred = new HashMap<>();
     private final Map<TopicPartition, Long> latestOffsets = new HashMap<>();
+    boolean outOfOrderCommits;
     private int batchSize;
     private List<MonoSink<Void>> callbackEmitters = new ArrayList<>();
 
     public synchronized int updateOffset(TopicPartition topicPartition, long offset) {
-        if (!((Long) offset).equals(consumedOffsets.put(topicPartition, offset))) {
+        if (this.outOfOrderCommits) {
+            this.deferred.computeIfAbsent(topicPartition, tp -> new LinkedList<>()).add(offset);
+            batchSize++;
+        } else if (!((Long) offset).equals(consumedOffsets.put(topicPartition, offset))) {
             batchSize++;
         }
         return batchSize;
@@ -53,16 +62,50 @@ class CommittableBatch {
         return batchSize;
     }
 
+    public synchronized void addUncommitted(ConsumerRecords<?, ?> records) {
+        records.partitions().forEach(tp -> {
+            List<Long> offsets = this.uncommitted.computeIfAbsent(tp, part -> new LinkedList<>());
+            records.records(tp).forEach(rec -> offsets.add(rec.offset()));
+        });
+    }
+
+    public synchronized int deferredCount() {
+        int count = 0;
+        for (List<Long> offsets : this.deferred.values()) {
+            count += offsets.size();
+        }
+        return count;
+    }
+
     public synchronized CommitArgs getAndClearOffsets() {
         Map<TopicPartition, OffsetAndMetadata> offsetMap = new HashMap<>();
-        latestOffsets.putAll(consumedOffsets);
-        Iterator<Map.Entry<TopicPartition, Long>> iterator = consumedOffsets.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<TopicPartition, Long> entry = iterator.next();
-            offsetMap.put(entry.getKey(), new OffsetAndMetadata(entry.getValue() + 1));
-            iterator.remove();
+        if (this.outOfOrderCommits) {
+            this.deferred.forEach((tp, offsets) -> {
+                if (offsets.size() > 0) {
+                    Collections.sort(offsets);
+                    List<Long> uncomittedThisPart = this.uncommitted.get(tp);
+                    long lastThisPart = -1;
+                    while (offsets.size() > 0 && offsets.get(0).equals(uncomittedThisPart.get(0))) {
+                        lastThisPart = offsets.get(0);
+                        offsets.remove(0);
+                        uncomittedThisPart.remove(0);
+                    }
+                    if (lastThisPart >= 0) {
+                        offsetMap.put(tp, new OffsetAndMetadata(lastThisPart + 1));
+                    }
+                }
+            });
+            batchSize = deferredCount();
+        } else {
+            latestOffsets.putAll(consumedOffsets);
+            Iterator<Map.Entry<TopicPartition, Long>> iterator = consumedOffsets.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<TopicPartition, Long> entry = iterator.next();
+                offsetMap.put(entry.getKey(), new OffsetAndMetadata(entry.getValue() + 1));
+                iterator.remove();
+            }
+            batchSize = 0;
         }
-        batchSize = 0;
 
         List<MonoSink<Void>> currentCallbackEmitters;
         if (!callbackEmitters.isEmpty()) {
@@ -76,12 +119,19 @@ class CommittableBatch {
 
     public synchronized void restoreOffsets(CommitArgs commitArgs, boolean restoreCallbackEmitters) {
         // Restore offsets that haven't been updated.
-        for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : commitArgs.offsets.entrySet()) {
-            TopicPartition topicPart = entry.getKey();
-            long offset = entry.getValue().offset();
-            Long latestOffset = latestOffsets.get(topicPart);
-            if (latestOffset == null || latestOffset <= offset - 1)
-                consumedOffsets.putIfAbsent(topicPart, offset - 1);
+        if (outOfOrderCommits) {
+            commitArgs.offsets.forEach((tp, offset) -> {
+                this.deferred.get(tp).add(0, offset.offset() - 1);
+                this.uncommitted.get(tp).add(0, offset.offset() - 1);
+            });
+        } else {
+            for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : commitArgs.offsets.entrySet()) {
+                TopicPartition topicPart = entry.getKey();
+                long offset = entry.getValue().offset();
+                Long latestOffset = latestOffsets.get(topicPart);
+                if (latestOffset == null || latestOffset <= offset - 1)
+                    consumedOffsets.putIfAbsent(topicPart, offset - 1);
+            }
         }
         // If Mono is being failed after maxAttempts or due to fatal error, callback emitters
         // are not restored. Mono#retry will generate new callback emitters. If Mono status

--- a/src/test/java/reactor/kafka/receiver/internals/OutOfOrderCommitsTests.java
+++ b/src/test/java/reactor/kafka/receiver/internals/OutOfOrderCommitsTests.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.kafka.receiver.internals;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+import reactor.core.Disposable;
+import reactor.core.scheduler.Schedulers;
+import reactor.kafka.receiver.KafkaReceiver;
+import reactor.kafka.receiver.ReceiverOptions;
+import reactor.kafka.receiver.ReceiverRecord;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Gary Russell
+ * @since 1.3.8
+ *
+ */
+public class OutOfOrderCommitsTests {
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void outOfOrderCommits() throws InterruptedException {
+        ConsumerFactory cf = mock(ConsumerFactory.class);
+        Consumer consumer = mock(Consumer.class);
+        given(cf.createConsumer(any())).willReturn(consumer);
+        AtomicReference<ConsumerRebalanceListener> listener = new AtomicReference<>();
+        TopicPartition tp0 = new TopicPartition("foo", 0);
+        Set<TopicPartition> assigned = Collections.singleton(tp0);
+        CountDownLatch subscribeLatch = new CountDownLatch(1);
+        willAnswer(inv -> {
+            listener.set(inv.getArgument(1));
+            listener.get().onPartitionsAssigned(Collections.singletonList(tp0));
+            subscribeLatch.countDown();
+            return null;
+        }).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+        CountDownLatch commitLatch = new CountDownLatch(1);
+        willAnswer(inv -> {
+            commitLatch.countDown();
+            return null;
+        }).given(consumer).commitAsync(any(), any());
+        final Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records = new HashMap<>();
+        records.put(new TopicPartition("foo", 0), Arrays.asList(
+            new ConsumerRecord<>("foo", 0, 0L, 1, "foo"),
+            new ConsumerRecord<>("foo", 0, 1L, 1, "bar"),
+            new ConsumerRecord<>("foo", 0, 2L, 1, "baz"),
+            new ConsumerRecord<>("foo", 0, 3L, 1, "qux")));
+        ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records);
+        AtomicBoolean first = new AtomicBoolean(true);
+        willAnswer(inv -> {
+            Thread.sleep(10);
+            if (first.getAndSet(false)) {
+                return consumerRecords;
+            }
+            return ConsumerRecords.empty();
+        }).given(consumer).poll(any(Duration.class));
+        given(consumer.assignment()).willReturn(assigned);
+        ReceiverOptions<Object, Object> options = ReceiverOptions.create()
+            .maxDeferredCommits(100)
+            .subscription(Collections.singletonList("foo"));
+        KafkaReceiver receiver = KafkaReceiver.create(cf, options);
+        List<ReceiverRecord<?, ?>> received = new ArrayList<>();
+        CountDownLatch latch = new CountDownLatch(4);
+        Disposable disposable = receiver.receive()
+            .publishOn(Schedulers.newSingle("ooo"))
+            .doOnNext(rec -> {
+                received.add((ReceiverRecord<?, ?>) rec);
+                latch.countDown();
+            })
+            .subscribe();
+        assertTrue(subscribeLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        received.get(3).receiverOffset().commit();
+        received.get(1).receiverOffset().commit();
+        received.get(2).receiverOffset().commit();
+        received.get(0).receiverOffset().commit();
+        assertTrue(commitLatch.await(10, TimeUnit.SECONDS));
+        verify(consumer, times(1)).commitAsync(any(), any());
+        Map<TopicPartition, OffsetAndMetadata> commits = new HashMap<>();
+        commits.put(new TopicPartition("foo", 0), new OffsetAndMetadata(4L));
+        verify(consumer).commitAsync(eq(commits), any());
+        disposable.dispose();
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void twoPartitions() throws InterruptedException {
+        ConsumerFactory cf = mock(ConsumerFactory.class);
+        Consumer consumer = mock(Consumer.class);
+        given(cf.createConsumer(any())).willReturn(consumer);
+        AtomicReference<ConsumerRebalanceListener> listener = new AtomicReference<>();
+        TopicPartition tp0 = new TopicPartition("foo", 0);
+        Set<TopicPartition> assigned = Collections.singleton(tp0);
+        CountDownLatch subscribeLatch = new CountDownLatch(1);
+        willAnswer(inv -> {
+            listener.set(inv.getArgument(1));
+            listener.get().onPartitionsAssigned(Collections.singletonList(tp0));
+            subscribeLatch.countDown();
+            return null;
+        }).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+        CountDownLatch commitLatch = new CountDownLatch(1);
+        willAnswer(inv -> {
+            commitLatch.countDown();
+            return null;
+        }).given(consumer).commitAsync(any(), any());
+        final Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records = new HashMap<>();
+        records.put(new TopicPartition("foo", 0), Arrays.asList(
+            new ConsumerRecord<>("foo", 0, 0L, 1, "foo"),
+            new ConsumerRecord<>("foo", 0, 1L, 1, "bar")));
+        records.put(new TopicPartition("foo", 1), Arrays.asList(
+            new ConsumerRecord<>("foo", 1, 0L, 1, "baz"),
+            new ConsumerRecord<>("foo", 1, 1L, 1, "qux")));
+        ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records);
+        AtomicBoolean first = new AtomicBoolean(true);
+        willAnswer(inv -> {
+            Thread.sleep(10);
+            if (first.getAndSet(false)) {
+                return consumerRecords;
+            }
+            return ConsumerRecords.empty();
+        }).given(consumer).poll(any(Duration.class));
+        given(consumer.assignment()).willReturn(assigned);
+        ReceiverOptions<Object, Object> options = ReceiverOptions.create()
+            .maxDeferredCommits(100)
+            .subscription(Collections.singletonList("foo"));
+        KafkaReceiver receiver = KafkaReceiver.create(cf, options);
+        List<ReceiverRecord<?, ?>> received = new ArrayList<>();
+        CountDownLatch latch = new CountDownLatch(4);
+        Disposable disposable = receiver.receive()
+            .publishOn(Schedulers.newSingle("ooo"))
+            .doOnNext(rec -> {
+                received.add((ReceiverRecord<?, ?>) rec);
+                latch.countDown();
+            })
+            .subscribe();
+        assertTrue(subscribeLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        received.get(3).receiverOffset().commit();
+        received.get(1).receiverOffset().commit();
+        received.get(2).receiverOffset().commit();
+        received.get(0).receiverOffset().commit();
+        assertTrue(commitLatch.await(10, TimeUnit.SECONDS));
+        verify(consumer, times(1)).commitAsync(any(), any());
+        Map<TopicPartition, OffsetAndMetadata> commits = new HashMap<>();
+        commits.put(new TopicPartition("foo", 0), new OffsetAndMetadata(2L));
+        commits.put(new TopicPartition("foo", 1), new OffsetAndMetadata(2L));
+        verify(consumer).commitAsync(eq(commits), any());
+        disposable.dispose();
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void pauseWhenTooManyDeferred() throws InterruptedException {
+        ConsumerFactory cf = mock(ConsumerFactory.class);
+        Consumer consumer = mock(Consumer.class);
+        given(cf.createConsumer(any())).willReturn(consumer);
+        AtomicReference<ConsumerRebalanceListener> listener = new AtomicReference<>();
+        TopicPartition tp0 = new TopicPartition("foo", 0);
+        Set<TopicPartition> assigned = Collections.singleton(tp0);
+        CountDownLatch subscribeLatch = new CountDownLatch(1);
+        willAnswer(inv -> {
+            listener.set(inv.getArgument(1));
+            listener.get().onPartitionsAssigned(Collections.singletonList(tp0));
+            subscribeLatch.countDown();
+            return null;
+        }).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+        CountDownLatch commitLatch = new CountDownLatch(1);
+        willAnswer(inv -> {
+            commitLatch.countDown();
+            return null;
+        }).given(consumer).commitAsync(any(), any());
+        final Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records = new HashMap<>();
+        records.put(new TopicPartition("foo", 0), Arrays.asList(
+            new ConsumerRecord<>("foo", 0, 0L, 1, "foo"),
+            new ConsumerRecord<>("foo", 0, 1L, 1, "bar"),
+            new ConsumerRecord<>("foo", 0, 2L, 1, "baz"),
+            new ConsumerRecord<>("foo", 0, 3L, 1, "qux")));
+        ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records);
+        AtomicBoolean first = new AtomicBoolean(true);
+        willAnswer(inv -> {
+            Thread.sleep(10);
+            if (first.getAndSet(false)) {
+                return consumerRecords;
+            }
+            return ConsumerRecords.empty();
+        }).given(consumer).poll(any(Duration.class));
+        given(consumer.assignment()).willReturn(assigned);
+        CountDownLatch pauseLatch = new CountDownLatch(1);
+        willAnswer(inv -> {
+            pauseLatch.countDown();
+            return null;
+        }).given(consumer).pause(any());
+        CountDownLatch resumeLatch = new CountDownLatch(1);
+        willAnswer(inv -> {
+            resumeLatch.countDown();
+            return null;
+        }).given(consumer).resume(any());
+        ReceiverOptions<Object, Object> options = ReceiverOptions.create()
+            .maxDeferredCommits(2)
+            .subscription(Collections.singletonList("foo"));
+        KafkaReceiver receiver = KafkaReceiver.create(cf, options);
+        List<ReceiverRecord<?, ?>> received = new ArrayList<>();
+        CountDownLatch latch = new CountDownLatch(4);
+        Disposable disposable = receiver.receive()
+            .publishOn(Schedulers.newSingle("ooo"))
+            .doOnNext(rec -> {
+                received.add((ReceiverRecord<?, ?>) rec);
+                latch.countDown();
+            })
+            .subscribe();
+        assertTrue(subscribeLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        received.get(3).receiverOffset().commit();
+        received.get(1).receiverOffset().commit();
+        received.get(2).receiverOffset().commit();
+        assertTrue(pauseLatch.await(10, TimeUnit.SECONDS));
+        received.get(0).receiverOffset().commit();
+        assertTrue(commitLatch.await(10, TimeUnit.SECONDS));
+        verify(consumer, times(1)).commitAsync(any(), any());
+        Map<TopicPartition, OffsetAndMetadata> commits = new HashMap<>();
+        commits.put(new TopicPartition("foo", 0), new OffsetAndMetadata(4L));
+        verify(consumer).commitAsync(eq(commits), any());
+        assertTrue(resumeLatch.await(10, TimeUnit.SECONDS));
+        disposable.dispose();
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void firstCommitFailed() throws InterruptedException {
+        ConsumerFactory cf = mock(ConsumerFactory.class);
+        Consumer consumer = mock(Consumer.class);
+        given(cf.createConsumer(any())).willReturn(consumer);
+        AtomicReference<ConsumerRebalanceListener> listener = new AtomicReference<>();
+        TopicPartition tp0 = new TopicPartition("foo", 0);
+        Set<TopicPartition> assigned = Collections.singleton(tp0);
+        CountDownLatch subscribeLatch = new CountDownLatch(1);
+        willAnswer(inv -> {
+            listener.set(inv.getArgument(1));
+            listener.get().onPartitionsAssigned(Collections.singletonList(tp0));
+            subscribeLatch.countDown();
+            return null;
+        }).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+        CountDownLatch commitLatch = new CountDownLatch(2);
+        willAnswer(inv -> {
+            commitLatch.countDown();
+            OffsetCommitCallback callback = inv.getArgument(1);
+            if (commitLatch.getCount() == 1) {
+                callback.onComplete(inv.getArgument(0), new RetriableCommitFailedException("test"));
+            } else {
+                callback.onComplete(inv.getArgument(0), null);
+            }
+            return null;
+        }).given(consumer).commitAsync(any(), any());
+        final Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records = new HashMap<>();
+        records.put(new TopicPartition("foo", 0), Arrays.asList(
+            new ConsumerRecord<>("foo", 0, 0L, 1, "foo"),
+            new ConsumerRecord<>("foo", 0, 1L, 1, "bar"),
+            new ConsumerRecord<>("foo", 0, 2L, 1, "baz"),
+            new ConsumerRecord<>("foo", 0, 3L, 1, "qux")));
+        ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records);
+        AtomicBoolean first = new AtomicBoolean(true);
+        willAnswer(inv -> {
+            Thread.sleep(10);
+            if (first.getAndSet(false)) {
+                return consumerRecords;
+            }
+            return ConsumerRecords.empty();
+        }).given(consumer).poll(any(Duration.class));
+        given(consumer.assignment()).willReturn(assigned);
+        ReceiverOptions<Object, Object> options = ReceiverOptions.create()
+            .maxDeferredCommits(100)
+            .subscription(Collections.singletonList("foo"));
+        KafkaReceiver receiver = KafkaReceiver.create(cf, options);
+        List<ReceiverRecord<?, ?>> received = new ArrayList<>();
+        CountDownLatch latch = new CountDownLatch(4);
+        Disposable disposable = receiver.receive()
+            .publishOn(Schedulers.newSingle("ooo"))
+            .doOnNext(rec -> {
+                received.add((ReceiverRecord<?, ?>) rec);
+                latch.countDown();
+            })
+            .subscribe();
+        assertTrue(subscribeLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        received.get(3).receiverOffset().commit();
+        received.get(1).receiverOffset().commit();
+        received.get(2).receiverOffset().commit();
+        received.get(0).receiverOffset().commit();
+        assertTrue(commitLatch.await(10, TimeUnit.SECONDS));
+        verify(consumer, times(2)).commitAsync(any(), any());
+        Map<TopicPartition, OffsetAndMetadata> commits = new HashMap<>();
+        commits.put(new TopicPartition("foo", 0), new OffsetAndMetadata(4L));
+        verify(consumer, times(2)).commitAsync(eq(commits), any());
+        disposable.dispose();
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void twoGaps() throws InterruptedException {
+        ConsumerFactory cf = mock(ConsumerFactory.class);
+        Consumer consumer = mock(Consumer.class);
+        given(cf.createConsumer(any())).willReturn(consumer);
+        AtomicReference<ConsumerRebalanceListener> listener = new AtomicReference<>();
+        TopicPartition tp0 = new TopicPartition("foo", 0);
+        Set<TopicPartition> assigned = Collections.singleton(tp0);
+        CountDownLatch subscribeLatch = new CountDownLatch(1);
+        willAnswer(inv -> {
+            listener.set(inv.getArgument(1));
+            listener.get().onPartitionsAssigned(Collections.singletonList(tp0));
+            subscribeLatch.countDown();
+            return null;
+        }).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+        CountDownLatch commitLatch1 = new CountDownLatch(1);
+        CountDownLatch commitLatch2 = new CountDownLatch(2);
+        willAnswer(inv -> {
+            commitLatch1.countDown();
+            commitLatch2.countDown();
+            return null;
+        }).given(consumer).commitAsync(any(), any());
+        final Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records = new HashMap<>();
+        records.put(new TopicPartition("foo", 0), Arrays.asList(
+            new ConsumerRecord<>("foo", 0, 0L, 1, "foo"),
+            new ConsumerRecord<>("foo", 0, 1L, 1, "bar"),
+            new ConsumerRecord<>("foo", 0, 2L, 1, "baz"),
+            new ConsumerRecord<>("foo", 0, 3L, 1, "qux")));
+        ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records);
+        AtomicBoolean first = new AtomicBoolean(true);
+        willAnswer(inv -> {
+            Thread.sleep(10);
+            if (first.getAndSet(false)) {
+                return consumerRecords;
+            }
+            return ConsumerRecords.empty();
+        }).given(consumer).poll(any(Duration.class));
+        given(consumer.assignment()).willReturn(assigned);
+        ReceiverOptions<Object, Object> options = ReceiverOptions.create()
+            .maxDeferredCommits(100)
+            .subscription(Collections.singletonList("foo"));
+        KafkaReceiver receiver = KafkaReceiver.create(cf, options);
+        List<ReceiverRecord<?, ?>> received = new ArrayList<>();
+        CountDownLatch latch = new CountDownLatch(4);
+        Disposable disposable = receiver.receive()
+            .publishOn(Schedulers.newSingle("ooo"))
+            .doOnNext(rec -> {
+                received.add((ReceiverRecord<?, ?>) rec);
+                latch.countDown();
+            })
+            .subscribe();
+        assertTrue(subscribeLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        received.get(3).receiverOffset().commit();
+        received.get(1).receiverOffset().commit();
+        received.get(0).receiverOffset().commit();
+        assertTrue(commitLatch1.await(10, TimeUnit.SECONDS));
+        verify(consumer, times(1)).commitAsync(any(), any());
+        Map<TopicPartition, OffsetAndMetadata> commits = new HashMap<>();
+        commits.put(new TopicPartition("foo", 0), new OffsetAndMetadata(2L));
+        verify(consumer).commitAsync(eq(commits), any());
+        received.get(2).receiverOffset().commit();
+        assertTrue(commitLatch2.await(10, TimeUnit.SECONDS));
+        verify(consumer, times(2)).commitAsync(any(), any());
+        commits = new HashMap<>();
+        commits.put(new TopicPartition("foo", 0), new OffsetAndMetadata(4L));
+        verify(consumer).commitAsync(eq(commits), any());
+        disposable.dispose();
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void outOfOrderAcks() throws InterruptedException {
+        ConsumerFactory cf = mock(ConsumerFactory.class);
+        Consumer consumer = mock(Consumer.class);
+        given(cf.createConsumer(any())).willReturn(consumer);
+        AtomicReference<ConsumerRebalanceListener> listener = new AtomicReference<>();
+        TopicPartition tp0 = new TopicPartition("foo", 0);
+        Set<TopicPartition> assigned = Collections.singleton(tp0);
+        CountDownLatch subscribeLatch = new CountDownLatch(1);
+        willAnswer(inv -> {
+            listener.set(inv.getArgument(1));
+            listener.get().onPartitionsAssigned(Collections.singletonList(tp0));
+            subscribeLatch.countDown();
+            return null;
+        }).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+        CountDownLatch commitLatch = new CountDownLatch(1);
+        willAnswer(inv -> {
+            commitLatch.countDown();
+            return null;
+        }).given(consumer).commitAsync(any(), any());
+        final Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records = new HashMap<>();
+        records.put(new TopicPartition("foo", 0), Arrays.asList(
+            new ConsumerRecord<>("foo", 0, 0L, 1, "foo"),
+            new ConsumerRecord<>("foo", 0, 1L, 1, "bar"),
+            new ConsumerRecord<>("foo", 0, 2L, 1, "baz"),
+            new ConsumerRecord<>("foo", 0, 3L, 1, "qux")));
+        ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records);
+        AtomicBoolean first = new AtomicBoolean(true);
+        willAnswer(inv -> {
+            Thread.sleep(10);
+            if (first.getAndSet(false)) {
+                return consumerRecords;
+            }
+            return ConsumerRecords.empty();
+        }).given(consumer).poll(any(Duration.class));
+        given(consumer.assignment()).willReturn(assigned);
+        ReceiverOptions<Object, Object> options = ReceiverOptions.create()
+            .maxDeferredCommits(100)
+            .commitBatchSize(4)
+            .subscription(Collections.singletonList("foo"));
+        KafkaReceiver receiver = KafkaReceiver.create(cf, options);
+        List<ReceiverRecord<?, ?>> received = new ArrayList<>();
+        CountDownLatch latch = new CountDownLatch(4);
+        Disposable disposable = receiver.receive()
+            .publishOn(Schedulers.newSingle("ooo"))
+            .doOnNext(rec -> {
+                received.add((ReceiverRecord<?, ?>) rec);
+                latch.countDown();
+            })
+            .subscribe();
+        assertTrue(subscribeLatch.await(10, TimeUnit.SECONDS));
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        received.get(3).receiverOffset().acknowledge();
+        received.get(1).receiverOffset().acknowledge();
+        received.get(2).receiverOffset().acknowledge();
+        received.get(0).receiverOffset().acknowledge();
+        assertTrue(commitLatch.await(10, TimeUnit.SECONDS));
+        verify(consumer, times(1)).commitAsync(any(), any());
+        Map<TopicPartition, OffsetAndMetadata> commits = new HashMap<>();
+        commits.put(new TopicPartition("foo", 0), new OffsetAndMetadata(4L));
+        verify(consumer).commitAsync(eq(commits), any());
+        disposable.dispose();
+    }
+
+}

--- a/src/test/java/reactor/kafka/sender/KafkaSenderTest.java
+++ b/src/test/java/reactor/kafka/sender/KafkaSenderTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.errors.InvalidProducerEpochException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -564,7 +565,7 @@ public class KafkaSenderTest extends AbstractKafkaTest {
                .blockLast(Duration.ofMillis(receiveTimeoutMillis));
 
         StepVerifier.create(kafkaSender.send(createSenderRecords(count * 2, count, false)))
-                    .expectError(ProducerFencedException.class)
+                    .expectError(InvalidProducerEpochException.class)
                     .verify(Duration.ofMillis(receiveTimeoutMillis));
 
         waitForMessages(consumer, count * 2, true);


### PR DESCRIPTION
Resolves https://github.com/reactor/reactor-kafka/issues/243

- retain a list of uncommitted offsets per partition
- defer commits for offsets that are not at the head of the list
- when a gap is filled, commit up to the next gap
- pause consumer when `maxDeferredCommits` reached