### PR TITLE
Upgrade log4j to 2.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ ext {
   joptVersion = '4.9'
 
   slf4jVersion = '1.7.30'
-  log4jVersion = '2.13.3'
+  log4jVersion = '2.15.0'
   junitVersion = '4.12'
   powermockVersion = '1.7.4'
   testcontainersVersion = '1.15.2'


### PR DESCRIPTION
This commit upgrade the log4j dependency.
Even though this is a test-only dependency, previous versions have a serious
vulnerability.