### PR TITLE
Support Exactly Once Semantics (EOS Mode BETA V2)

### DIFF
--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
@@ -71,7 +71,7 @@ class ConsumerHandler<K, V> {
 
     private final ReceiverOptions<K, V> receiverOptions;
 
-    private final Consumer<K, V> consumer;
+    final Consumer<K, V> consumer;
 
     private final Scheduler eventScheduler;
 

--- a/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
@@ -109,7 +109,7 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V> {
                                 .sendOffsets(offsetBatch
                                     .getAndClearOffsets()
                                     .offsets(),
-                                    receiverOptions.groupId()))
+                                    handler.consumer.groupMetadata()))
                             .doAfterTerminate(() -> handler.awaitingTransaction.set(false));
                     });
             return resultFlux.publishOn(transactionManager.scheduler(), preparePublishOnQueueSize(prefetch));

--- a/src/main/java/reactor/kafka/sender/TransactionManager.java
+++ b/src/main/java/reactor/kafka/sender/TransactionManager.java
@@ -18,6 +18,7 @@ package reactor.kafka.sender;
 
 import java.util.Map;
 
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.TopicPartition;
@@ -53,8 +54,25 @@ public interface TransactionManager {
      * @param consumerGroupId The consumer group id for which offsets are updated
      * @return empty {@link Mono} that completes when the offsets have been sent to the consumer offsets topic.
      *         The offsets will be committed when the current transaction is committed.
+     * @deprecated in favor of #sendOffsets(Map<TopicPartition, OffsetAndMetadata>, ConsumerGroupMetadata)
      */
+    @Deprecated
     <T> Mono<T> sendOffsets(Map<TopicPartition, OffsetAndMetadata> offsets, String consumerGroupId);
+
+    /**
+     * Sends provided offsets to the consumer offsets topic. Offsets are updated within the current transaction.
+     * See {@link KafkaProducer#sendOffsetsToTransaction(Map, ConsumerGroupMetadata)} for details on updating consumer
+     * offsets within a transaction.
+     *
+     * @param offsets Consumer offsets to update
+     * @param metadata The consumer group metadata
+     * @return empty {@link Mono} that completes when the offsets have been sent to the consumer offsets topic.
+     *         The offsets will be committed when the current transaction is committed.
+     * @since 1.3.9
+     */
+    default <T> Mono<T> sendOffsets(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata metadata) {
+        return sendOffsets(offsets, metadata.groupId());
+    }
 
     /**
      * Commits the current transaction. See {@link KafkaProducer#commitTransaction()} for details.

--- a/src/main/java/reactor/kafka/sender/internals/DefaultTransactionManager.java
+++ b/src/main/java/reactor/kafka/sender/internals/DefaultTransactionManager.java
@@ -16,6 +16,7 @@
 
 package reactor.kafka.sender.internals;
 
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.TopicPartition;
@@ -46,10 +47,21 @@ class DefaultTransactionManager<K, V> implements TransactionManager {
     }
 
     @Override
+    @Deprecated
     public <T> Mono<T> sendOffsets(Map<TopicPartition, OffsetAndMetadata> offsets, String consumerGroupId) {
         return producerMono.flatMap(producer -> Mono.fromRunnable(() -> {
             if (!offsets.isEmpty()) {
                 producer.sendOffsetsToTransaction(offsets, consumerGroupId);
+                DefaultKafkaSender.log.trace("Sent offsets to transaction for producer {}, offsets: {}", senderOptions.transactionalId(), offsets);
+            }
+        }));
+    }
+
+    @Override
+    public <T> Mono<T> sendOffsets(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata metadata) {
+        return producerMono.flatMap(producer -> Mono.fromRunnable(() -> {
+            if (!offsets.isEmpty()) {
+                producer.sendOffsetsToTransaction(offsets, metadata);
                 DefaultKafkaSender.log.trace("Sent offsets to transaction for producer {}, offsets: {}", senderOptions.transactionalId(), offsets);
             }
         }));

--- a/src/test/java/reactor/kafka/mock/MockConsumer.java
+++ b/src/test/java/reactor/kafka/mock/MockConsumer.java
@@ -18,6 +18,7 @@ package reactor.kafka.mock;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -42,6 +43,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -107,6 +109,11 @@ public class MockConsumer extends org.apache.kafka.clients.consumer.MockConsumer
     public void addCommitException(KafkaException exception, int count) {
         for (int i = 0; i < count; i++)
             commitExceptions.add(exception);
+    }
+
+    @Override
+    public ConsumerGroupMetadata groupMetadata() {
+        return new ConsumerGroupMetadata(receiverOptions.groupId(), 1, "1", Optional.empty());
     }
 
     public long pollCount() {

--- a/src/test/java/reactor/kafka/sender/internals/MockTransactionTest.java
+++ b/src/test/java/reactor/kafka/sender/internals/MockTransactionTest.java
@@ -17,6 +17,7 @@
 package reactor.kafka.sender.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -332,7 +333,7 @@ public class MockTransactionTest {
             this.consumerGroupId = consumerGroupId;
         }
         Mono<Void> commit() {
-            return transactionManager.sendOffsets(offsets, consumerGroupId).then(transactionManager.commit());
+            return transactionManager.sendOffsets(offsets, new ConsumerGroupMetadata(consumerGroupId)).then(transactionManager.commit());
         }
         Mono<Void> commitAndBegin() {
             return commit().then(transactionManager.begin());


### PR DESCRIPTION
Resolves https://github.com/reactor/reactor-kafka/issues/207

Use `sendOffsetsToTransaction` that takes `ConsumerGroupMetadata` instead of
just he consumer `group.id`.

`kafka-clients` will currently downgrade to `ALPHA` (V1) if the broker is
earlier than 2.5.