### PR TITLE
Swap out SimpleDateFormat with DateTimeFormatter

### DIFF
--- a/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleConsumer.java
+++ b/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleConsumer.java
+++ b/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleConsumer.java
@@ -16,9 +16,9 @@
 
 package reactor.kafka.samples;
 
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -57,7 +57,7 @@ public class SampleConsumer {
     private static final String TOPIC = "demo-topic";
 
     private final ReceiverOptions<Integer, String> receiverOptions;
-    private final SimpleDateFormat dateFormat;
+    private final DateTimeFormatter dateFormat;
 
     public SampleConsumer(String bootstrapServers) {
 
@@ -69,7 +69,7 @@ public class SampleConsumer {
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         receiverOptions = ReceiverOptions.create(props);
-        dateFormat = new SimpleDateFormat("HH:mm:ss:SSS z dd MMM yyyy");
+        dateFormat = DateTimeFormatter.ofPattern("HH:mm:ss:SSS z dd MMM yyyy");
     }
 
     public Disposable consumeMessages(String topic, CountDownLatch latch) {
@@ -80,10 +80,11 @@ public class SampleConsumer {
         Flux<ReceiverRecord<Integer, String>> kafkaFlux = KafkaReceiver.create(options).receive();
         return kafkaFlux.subscribe(record -> {
             ReceiverOffset offset = record.receiverOffset();
+            Instant timestamp = Instant.ofEpochMilli(record.timestamp());
             System.out.printf("Received message: topic-partition=%s offset=%d timestamp=%s key=%d value=%s\n",
                     offset.topicPartition(),
                     offset.offset(),
-                    dateFormat.format(new Date(record.timestamp())),
+                    dateFormat.format(timestamp),
                     record.key(),
                     record.value());
             offset.acknowledge();

--- a/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleProducer.java
+++ b/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleProducer.java
+++ b/reactor-kafka-samples/src/main/java/reactor/kafka/samples/SampleProducer.java
@@ -16,8 +16,8 @@
 
 package reactor.kafka.samples;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.format.DateTimeFormatter;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -55,7 +55,7 @@ public class SampleProducer {
     private static final String TOPIC = "demo-topic";
 
     private final KafkaSender<Integer, String> sender;
-    private final SimpleDateFormat dateFormat;
+    private final DateTimeFormatter dateFormat;
 
     public SampleProducer(String bootstrapServers) {
 
@@ -68,7 +68,7 @@ public class SampleProducer {
         SenderOptions<Integer, String> senderOptions = SenderOptions.create(props);
 
         sender = KafkaSender.create(senderOptions);
-        dateFormat = new SimpleDateFormat("HH:mm:ss:SSS z dd MMM yyyy");
+        dateFormat = DateTimeFormatter.ofPattern("HH:mm:ss:SSS z dd MMM yyyy");
     }
 
     public void sendMessages(String topic, int count, CountDownLatch latch) throws InterruptedException {
@@ -77,12 +77,13 @@ public class SampleProducer {
               .doOnError(e -> log.error("Send failed", e))
               .subscribe(r -> {
                   RecordMetadata metadata = r.recordMetadata();
+                  Instant timestamp = Instant.ofEpochMilli(metadata.timestamp());
                   System.out.printf("Message %d sent successfully, topic-partition=%s-%d offset=%d timestamp=%s\n",
                       r.correlationMetadata(),
                       metadata.topic(),
                       metadata.partition(),
                       metadata.offset(),
-                      dateFormat.format(new Date(metadata.timestamp())));
+                      dateFormat.format(timestamp));
                   latch.countDown();
               });
     }


### PR DESCRIPTION
SimpleDateFormat is not threadsafe, and so has been swapped out with the threadsafe DateTimeFormatter implementation instead.