### PR TITLE
KafkaReceiverTest.transactionalOffsetCommit Fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,15 @@ jobs:
       - name: run checks
         id: checks
         run: ./gradlew check
+      - name: Capture Test Results
+        if: failure() && steps.gradle.outcome == 'failure'
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # renovate: tag=v2
+        with:
+          name: test-results
+          path: |
+            build/reports/tests/**/*.*
+            */build/reports/tests/**/*.*
+          retention-days: 3
 
   #deploy the snapshot artifacts to Artifactory
   deploySnapshot:

--- a/src/main/java/reactor/kafka/sender/TransactionManager.java
+++ b/src/main/java/reactor/kafka/sender/TransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
 
 package reactor.kafka.sender;
 
-import java.util.Map;
-
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.TopicPartition;
-
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
+
+import java.util.Map;
+import java.util.function.Consumer;
 
 public interface TransactionManager {
 
@@ -95,5 +95,15 @@ public interface TransactionManager {
      * @return the scheduler associated with this transaction instance.
      */
     Scheduler scheduler();
+
+    /**
+     * A callback to indicate a commit or rollback has completed, true for commit.
+     * @param txComplete the commitComplete to set.
+     * @return the manager;
+     * @since 1.3.12
+     */
+    default TransactionManager transactionComplete(Consumer<Boolean> txComplete) {
+        return this;
+    }
 
 }

--- a/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
@@ -26,7 +26,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -676,7 +675,6 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
     }
 
     @Test
-    @Ignore("to investigate, flaky since 1.3.11")
     public void autoCommitFailurePropagationAfterRetries() throws Exception {
         int count = 5;
         receiverOptions = receiverOptions.consumerProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
@@ -1419,6 +1417,7 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
 
         int maybeRedelivered = maxRedelivered - minRedelivered;
         CountDownLatch latch = new CountDownLatch(sendCount + maxRedelivered);
+        clearReceivedMessages();
         subscribe(kafkaFlux, latch);
         sendMessages(sendStartIndex, sendCount);
 

--- a/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
@@ -92,6 +92,7 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
 
     private final Semaphore assignSemaphore = new Semaphore(0);
     private final List<Disposable> subscribeDisposables = new ArrayList<>();
+    private final Set<Integer> committedRecords = Collections.synchronizedSet(new HashSet<>());
 
     @After
     public void tearDown() {
@@ -1200,8 +1201,9 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
     }
 
     @Test
-    @Ignore("to investigate, flaky before release of 1.3.11")
+//    @Ignore("to investigate, flaky before release of 1.3.11")
     public void transactionalOffsetCommit() throws Exception {
+        committedRecords.clear();
         String destTopic = createNewTopic();
 
         int count = 10;
@@ -1214,9 +1216,12 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
         KafkaSender<Integer, String> txSender = createTransactionalSender();
         KafkaReceiver<Integer, String> receiver = createReceiver();
 
-        receiveAndSendTransactions(receiver, txSender, destTopic, count, 4)
-            .onErrorResume(e -> txSender.transactionManager().abort().thenMany(receiveAndSendTransactions(receiver, txSender, destTopic, count - 2, -1)))
-            .blockLast(Duration.ofMillis(receiveTimeoutMillis));
+        Semaphore completion = new Semaphore(0);
+        receiveAndSendTransactions(receiver, txSender, destTopic, count, 4, completion)
+            .onErrorResume(e -> txSender.transactionManager().abort()
+                    .thenMany(receiveAndSendTransactions(receiver, txSender, destTopic, count, -1, completion)))
+            .subscribe();
+        assertTrue(completion.tryAcquire(receiveTimeoutMillis, TimeUnit.MILLISECONDS));
 
         // Check that exactly 'count' messages is committed on destTopic, with one copy of each message
         // from source topic
@@ -1225,8 +1230,10 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
                 .subscription(Collections.singletonList(destTopic))
                 .clearAssignListeners()
                 .addAssignListener(partitions -> assignSemaphore.release());
+        this.topic = destTopic;
         CountDownLatch latch = new CountDownLatch(count);
-        subscribe(createReceiver().receive(), latch);
+        subscribe(createReceiver().receive().doOnNext(r ->
+                log.info("Dest Received: {}-{}@{} ({})", r.topic(), r.partition(), r.offset(), r.key())), latch);
         waitForMessages(latch);
         checkConsumedMessages(0, count);
     }
@@ -1530,20 +1537,36 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
     }
 
     private Flux<SenderResult<Integer>> receiveAndSendTransactions(KafkaReceiver<Integer, String> receiver,
-            KafkaSender<Integer, String> sender, String destTopic, int count, int exceptionIndex) {
+            KafkaSender<Integer, String> sender, String destTopic, int count, int exceptionIndex,
+            Semaphore completion) {
+
         AtomicInteger index = new AtomicInteger();
-        TransactionManager transactionManager = sender.transactionManager();
+        TransactionManager transactionManager = sender.transactionManager()
+                .transactionComplete(bool -> {
+                    log.info("Commit complete {} - {}", bool, committedRecords);
+                    if (bool && committedRecords.size() == count) {
+                        completion.release();
+                    }
+                });
+
         return receiver.receiveExactlyOnce(transactionManager)
                 .concatMap(f ->
                     sender.send(
-                        f.map(r -> toSenderRecord(destTopic, r, r.key()))
+                        f.map(r -> {
+                            log.info("Received: {}-{}@{} ({})", r.topic(), r.partition(), r.offset(), r.key());
+                            committedRecords.add(r.key());
+                            return toSenderRecord(destTopic, r, r.key());
+                        })
                          .doOnNext(r -> {
                              if (index.incrementAndGet() == exceptionIndex) {
                                  throw new RuntimeException("Test exception");
                              }
-                         })
-                    ).concatWith(transactionManager.commit())
-                )
-                .take(count);
+                         }))
+                    .concatWith(transactionManager.commit())
+                    .doOnNext(sr -> {
+                        log.info("Sent: {}-{}@{}",
+                            sr.recordMetadata().topic(), sr.recordMetadata().partition(), sr.recordMetadata().offset());
+                    })
+                );
     }
 }

--- a/src/test/java/reactor/kafka/receiver/internals/CommitRetryTests.java
+++ b/src/test/java/reactor/kafka/receiver/internals/CommitRetryTests.java
@@ -132,7 +132,7 @@ public class CommitRetryTests {
         verify(scheduler, times(4)).schedule(any(), eq(11L), eq(TimeUnit.MILLISECONDS));
     }
 
-    private Scheduler injectMockScheduler(KafkaReceiver receiver) throws Exception {
+    private Scheduler injectMockScheduler(KafkaReceiver<?, ?> receiver) throws Exception {
         Field handlerField = DefaultKafkaReceiver.class.getDeclaredField("consumerHandler");
         handlerField.setAccessible(true);
         Object eventLoop = handlerField.get(receiver);

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -28,6 +28,7 @@
     <Logger name="org.apache.kafka.clients.consumer.ConsumerConfig" level="warn"/>
     <Logger name="reactor" level="info"/>
     <Logger name="reactor.kafka" level="off"/>
+    <Logger name="reactor.kafka.receiver.KafkaReceiverTest" level="info"/>
     <Logger name="reactor.Flux.Interval" level="off"/>
     <Logger name="reactor.Flux.FlatMap.10" level="off"/>
     <Logger name="reactor.Flux.Map.8" level="off"/>


### PR DESCRIPTION
See https://github.com/reactor/reactor-kafka/issues/274

This test had several problems:

The second part of the test was receiving from the original topic instead
of the destination topic so it always succeeeded in finding all the records.

When this was changed to consume from the proper topic, it always failed.

This was because the `.take(count)` in `receiveAndSendTransactions` caused
the flux to be canceled before the final commit took place.

Added a callback hook to the `TransactionManager` so we can test that the commit
is complete before terminating the flux.

It is not clear whether these fixes will resolve the original problem so I
have left diagnostics for future failure analysis.

Also capture test results in the publish action.