### PR TITLE
Fix Pause During Back Pressure

### DIFF
--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -171,6 +172,11 @@ class ConsumerHandler<K, V> {
         InvocationHandler handler = (proxy, method, args) -> {
             if (DELEGATE_METHODS.contains(method.getName())) {
                 try {
+                    if (method.getName().equals("pause")) {
+                        this.consumerEventLoop.paused((Collection<TopicPartition>) args[0]);
+                    } else if (method.getName().equals("resume")) {
+                        this.consumerEventLoop.resumed((Collection<TopicPartition>) args[0]);
+                    }
                     return method.invoke(consumer, args);
                 } catch (InvocationTargetException e) {
                     throw e.getCause();

--- a/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
@@ -1341,11 +1341,14 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
                 .untilAsserted(() ->
             assertThat(receiver.doOnConsumer(org.apache.kafka.clients.consumer.Consumer::paused)
                     .block(Duration.ofSeconds(5L))).hasSize(4));
+        CountDownLatch latch3 = new CountDownLatch(1);
         receiver.doOnConsumer(consumer -> {
             consumer.pause(Collections.singletonList(new TopicPartition(this.topic, 0)));
+            latch3.countDown();
             return null;
         }).block(Duration.ofSeconds(5));
         latch1.countDown();
+        assertThat(latch3.await(10, TimeUnit.SECONDS)).isTrue();
         await().alias("Should not resume user pause")
                 .untilAsserted(() ->
             assertThat(receiver.doOnConsumer(org.apache.kafka.clients.consumer.Consumer::paused)

--- a/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
@@ -677,7 +677,7 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
     }
 
     @Test
-    @Ignore
+    @Ignore("flaky")
     public void autoCommitFailurePropagationAfterRetries() throws Exception {
         int count = 5;
         receiverOptions = receiverOptions.consumerProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")


### PR DESCRIPTION
If a user pauses partitions, then back pressure is applied, pausing all partitions,
the user paused partitions are not resumed when the back pressure is relieved.

However, if back pressure is in place when the user pauses partitions, they are
resumed when the back pressure is relieved.

Instead of determining user paused partitions dynamically, maintain a collection
thereof when the user invokes pause or resume on the consumer.