### PR TITLE
GH-301: Improve Partitions Resumed Log

### DIFF
--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
@@ -313,7 +313,9 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
                                 Set<TopicPartition> toResume = new HashSet<>(consumer.assignment());
                                 toResume.removeAll(ConsumerEventLoop.this.pausedByUser);
                                 consumer.resume(toResume);
-                                log.debug("Resumed");
+                                if (log.isDebugEnabled()) {
+                                    log.debug("Resumed partitions: " + toResume);
+                                }
                             }
                         } else {
                             if (checkAndSetPausedByUs()) {

--- a/src/test/java/reactor/kafka/receiver/internals/OutOfOrderCommitsTests.java
+++ b/src/test/java/reactor/kafka/receiver/internals/OutOfOrderCommitsTests.java
@@ -494,7 +494,7 @@ public class OutOfOrderCommitsTests {
             subscribeLatch.countDown();
             return null;
         }).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
-        CountDownLatch commitLatch = new CountDownLatch(1);
+        CountDownLatch commitLatch = new CountDownLatch(4);
         willAnswer(inv -> {
             commitLatch.countDown();
             return null;


### PR DESCRIPTION
Resolves https://github.com/reactor/reactor-kafka/issues/301

Also fix race in `OutOfOrderCommitsTests.rebalance()`.