### PR TITLE
GH-314: Fix Cooperative Incremental Rebalance

### DIFF
--- a/src/main/java/reactor/kafka/receiver/internals/CommittableBatch.java
+++ b/src/main/java/reactor/kafka/receiver/internals/CommittableBatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ class CommittableBatch {
     private int inPipeline;
 
     public synchronized int updateOffset(TopicPartition topicPartition, long offset) {
+        log.trace("Update offset {}@{}", topicPartition, offset);
         if (this.outOfOrderCommits) {
             SortedSet<Long> uncommittedThisTP = this.uncommitted.get(topicPartition);
             if (uncommittedThisTP != null && uncommittedThisTP.contains(offset)) {

--- a/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/internals/DefaultKafkaReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package reactor.kafka.receiver.internals;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
@@ -42,7 +43,8 @@ public class DefaultKafkaReceiver<K, V> implements KafkaReceiver<K, V> {
 
     private final ReceiverOptions<K, V> receiverOptions;
 
-    Predicate<Throwable> isRetriableException = RetriableCommitFailedException.class::isInstance;
+    Predicate<Throwable> isRetriableException = t -> RetriableCommitFailedException.class.isInstance(t)
+            || RebalanceInProgressException.class.isInstance(t);
 
     ConsumerHandler<K, V> consumerHandler;
 


### PR DESCRIPTION
Resolves https://github.com/reactor/reactor-kafka/issues/314

During cooperative rebalancing, e.g. with `CooperativeStickyAssignor` commits can result in `RebalanceInProgressException`; this exception represents a retryable condition, even though that exception does not extend the existing `RetriableCommitFailedException` or its super interface `RetriableException` so the event loop does not retry these exceptions.

Add this exception to the retryable exception list. Also, do not pause the consumer during retries because it can continue to consume from partitions that were not revoked by the cooperative rebalance.

Add unit test; integration testing was performed with the code provided in the original issue #314.