### PR TITLE
Fix invasive logging (#309)

### DIFF
--- a/src/main/java/reactor/kafka/sender/internals/SendSubscriber.java
+++ b/src/main/java/reactor/kafka/sender/internals/SendSubscriber.java
@@ -97,7 +97,7 @@ class SendSubscriber<K, V, C> implements CoreSubscriber<ProducerRecord<K, V>> {
             }
 
             if (exception != null) {
-                DefaultKafkaSender.log.trace("Sender failed: $exception ");
+                DefaultKafkaSender.log.trace("Sender failed: $exception");
                 firstException.compareAndSet(null, exception);
                 if (senderOptions.stopOnError() || senderOptions.fatalException(exception)) {
                     onError(exception);

--- a/src/main/java/reactor/kafka/sender/internals/SendSubscriber.java
+++ b/src/main/java/reactor/kafka/sender/internals/SendSubscriber.java
@@ -97,7 +97,7 @@ class SendSubscriber<K, V, C> implements CoreSubscriber<ProducerRecord<K, V>> {
             }
 
             if (exception != null) {
-                DefaultKafkaSender.log.trace("Sender failed: ", exception");
+                DefaultKafkaSender.log.trace("Sender failed: ", exception);
                 firstException.compareAndSet(null, exception);
                 if (senderOptions.stopOnError() || senderOptions.fatalException(exception)) {
                     onError(exception);

--- a/src/main/java/reactor/kafka/sender/internals/SendSubscriber.java
+++ b/src/main/java/reactor/kafka/sender/internals/SendSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/reactor/kafka/sender/internals/SendSubscriber.java
+++ b/src/main/java/reactor/kafka/sender/internals/SendSubscriber.java
@@ -97,7 +97,7 @@ class SendSubscriber<K, V, C> implements CoreSubscriber<ProducerRecord<K, V>> {
             }
 
             if (exception != null) {
-                DefaultKafkaSender.log.trace("Sender failed: $exception");
+                DefaultKafkaSender.log.trace("Sender failed: ", exception");
                 firstException.compareAndSet(null, exception);
                 if (senderOptions.stopOnError() || senderOptions.fatalException(exception)) {
                     onError(exception);

--- a/src/main/java/reactor/kafka/sender/internals/SendSubscriber.java
+++ b/src/main/java/reactor/kafka/sender/internals/SendSubscriber.java
@@ -97,7 +97,7 @@ class SendSubscriber<K, V, C> implements CoreSubscriber<ProducerRecord<K, V>> {
             }
 
             if (exception != null) {
-                DefaultKafkaSender.log.error("Sender failed", exception);
+                DefaultKafkaSender.log.trace("Sender failed: $exception ");
                 firstException.compareAndSet(null, exception);
                 if (senderOptions.stopOnError() || senderOptions.fatalException(exception)) {
                     onError(exception);


### PR DESCRIPTION
Fix for #309 
Changed log level to trace. Full reasoning in the issue, but in summary: the error is thrown anyways and can/should be managed/logged by the users of the library. The logging statement in the internal file was on `error` level, which is too high and caused issues in our monitoring system.