### PR TITLE
newArgumentParser was deprecated

### DIFF
--- a/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ConsumerPerformance.java
+++ b/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ConsumerPerformance.java
@@ -104,7 +104,9 @@ public class ConsumerPerformance {
 
     /** Get the command-line argument parser. */
     private static ArgumentParser argParser() {
-        ArgumentParser parser = ArgumentParsers.newArgumentParser("consumer-performance").defaultHelp(true)
+        ArgumentParser parser = ArgumentParsers.newFor("consumer-performance")
+                .addHelp(true)
+                .build()
                 .description("This tool is used to verify the consumer performance.");
 
         parser.addArgument("--topic")

--- a/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/EndToEndLatency.java
+++ b/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/EndToEndLatency.java
@@ -121,7 +121,9 @@ public class EndToEndLatency {
 
     /** Get the command-line argument parser. */
     private static ArgumentParser argParser() {
-        ArgumentParser parser = ArgumentParsers.newArgumentParser("end-to-end-latency").defaultHelp(true)
+        ArgumentParser parser = ArgumentParsers.newFor("end-to-end-latency")
+                .addHelp(true)
+                .build()
                 .description("This tool is used to verify end to end latency.");
 
         parser.addArgument("--bootstrap-servers")

--- a/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ProducerPerformance.java
+++ b/reactor-kafka-tools/src/main/java/reactor/kafka/tools/perf/ProducerPerformance.java
@@ -108,8 +108,9 @@ public class ProducerPerformance {
     /** Get the command-line argument parser. */
     private static ArgumentParser argParser() {
         ArgumentParser parser = ArgumentParsers
-                .newArgumentParser("producer-performance")
-                .defaultHelp(true)
+                .newFor("producer-performance")
+                .addHelp(true)
+                .build()
                 .description("This tool is used to verify the producer performance.");
 
         parser.addArgument("--topic")


### PR DESCRIPTION
This gets rid of some Warning: 
<img width="1693" alt="Screenshot 2023-04-17 at 12 51 33 pm" src="https://user-images.githubusercontent.com/5586453/232366516-d8d3a336-5986-4233-8fbc-ca1d948b7361.png">

nothing should change except moving away from deprecated method to build arg, after the change:
```
java -cp .:reactor-kafka-tools-1.3.18-SNAPSHOT.jar:argparse4j-0.9.0.jar reactor.kafka.tools.perf.ProducerPerformance

usage: producer-performance [-h] --topic TOPIC --num-records NUM-RECORDS --record-size RECORD-SIZE --throughput THROUGHPUT --producer-props PROP-NAME=PROP-VALUE [PROP-NAME=PROP-VALUE ...] [--reactive REACTIVE] [--transactional-id TRANSACTIONAL-ID]
                            [--transaction-duration-ms TRANSACTION-DURATION]

This tool is used to verify the producer performance.

named arguments:
  -h, --help             show this help message and exit
  --topic TOPIC          produce messages to this topic
  --num-records NUM-RECORDS
                         number of messages to produce
  --record-size RECORD-SIZE
                         message size in bytes
  --throughput THROUGHPUT
                         throttle maximum message throughput to *approximately* THROUGHPUT messages/sec
  --producer-props PROP-NAME=PROP-VALUE [PROP-NAME=PROP-VALUE ...]
                         kafka producer related configuration properties like bootstrap.servers,client.id etc..
  --reactive REACTIVE    if true, use reactive API
  --transactional-id TRANSACTIONAL-ID
                         The transactionalId to use if transaction-duration-ms is > 0. Useful when testing the performance of concurrent transactions.
  --transaction-duration-ms TRANSACTION-DURATION
                         The max age of each transaction. The commitTransaction will be called after this this time has elapsed. Transactions are only enabled if this value is positive.
```