### PR TITLE
Add receive batch to receiver

### DIFF
--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -458,6 +458,37 @@ based on the configured commit interval and batch size. This mode is simple to u
 do not need to perform any acknowledge or commit actions. It is efficient as well and can be used
 for at-least-once delivery of messages.
 
+==== Manual acknowledgement of batches of records
+
+`KafkaReceiver#receiveBatch` returns a `Flux` of batches of records returned by each `KafkaConsumer#poll()`.
+The records in each batch should be manually acknowledged or committed.
+[source,java]
+--------
+KafkaReceiver.create(receiverOptions)
+             .receiveBatch()
+             .concatMap(b -> b)                                      // <1>
+             .subscribe(r -> {
+                 System.out.println("Received message: " + r);       // <2>
+                 r.receiverOffset().acknowledge();                   // <3>
+             });
+--------
+<1> Concatenate in order
+<2> Print out each consumer record received
+<3> Explicit ack for each message
+
+Same as the `KafkaReceiver#receiveAutoAck` method, the maximum number of records in each batch can be controlled
+using the `KafkaConsumer` property `MAX_POLL_RECORDS`. This is used together with the fetch size and wait times
+configured on the KafkaConsumer to control the amount of data fetched from Kafka brokers in each poll.
+But unlike the `KafkaReceiver#receiveAutoAck`, each batch is returned as a Flux that should be acknowledged
+or committed using `ReceiverOffset`.
+
+As the `KafkaReceiver#receive` method messages, each message in the batch is represented as a `ReceiverRecord`
+which has a committable `ReceiverOffset` instance.
+
+`KafkaReceiver#receiveBatch` combines the batch consumption mode of `KafkaReceiver#receiveAutoAck` with the manual
+acknowledgement/commit mode of `KafkaReceiver#receive`. This batching mode is efficient and is easy to use
+for at-least-once delivery of messages.
+
 ==== Disabling automatic commits
 
 Applications which don't require offset commits to Kafka may disable automatic commits by not acknowledging
@@ -526,7 +557,7 @@ By default, receivers start consuming records from the last committed offset of 
 If a committed offset is not available, the offset reset strategy `ConsumerConfig#AUTO_OFFSET_RESET_CONFIG`
 configured for the `KafkaConsumer` is used to set the start offset to the earliest or latest offset on the partition.
 Applications can override offsets by seeking to new offsets in an assignment listener. Methods are provided on
-`ReceiverPartition` to seek to the earliest, latest, a specific offset in the partition, or to a record with 
+`ReceiverPartition` to seek to the earliest, latest, a specific offset in the partition, or to a record with
 a timestamp later than a point in time.
 
 

--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -455,7 +455,7 @@ The maximum number of records in each batch can be controlled using the `KafkaCo
 KafkaConsumer to control the amount of data fetched from Kafka brokers in each poll. Each batch is
 returned as a Flux that is acknowledged after the Flux terminates. Acknowledged records are committed periodically
 based on the configured commit interval and batch size. This mode is simple to use since applications
-do not need to perform any acknowledge or commit actions. It is efficient as well and can be used
+do not need to perform any acknowledge or commit actions. It is efficient as well but can not be used
 for at-least-once delivery of messages.
 
 ==== Manual acknowledgement of batches of records

--- a/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,6 +95,35 @@ public interface KafkaReceiver<K, V> {
      */
     default Flux<ReceiverRecord<K, V>> receive() {
         return receive(null);
+    }
+
+    /**
+     * Returns a {@link Flux} containing each batch of consumer records returned by {@link Consumer#poll(long)}.
+     * The maximum number of records returned in each batch can be configured on {@link ReceiverOptions} by setting
+     * the consumer property {@link ConsumerConfig#MAX_POLL_RECORDS_CONFIG}. Each batch is returned as one Flux.
+     * Every record must be acknowledged using ReceiverOffset.acknowledge() in order to commit the offset
+     * corresponding to the record. Acknowledged records are committed based on the configured commit interval
+     * and commit batch size in ReceiverOptions. Records may also be committed manually using ReceiverOffset.commit().
+     *
+     * @param prefetch amount of prefetched batches
+     * @return Flux of consumer record batches from Kafka that are committed only after acknowledgement
+     * @since 1.3.21
+     */
+    Flux<Flux<ReceiverRecord<K, V>>> receiveBatch(Integer prefetch);
+
+    /**
+     * Returns a {@link Flux} containing each batch of consumer records returned by {@link Consumer#poll(long)}.
+     * The maximum number of records returned in each batch can be configured on {@link ReceiverOptions} by setting
+     * the consumer property {@link ConsumerConfig#MAX_POLL_RECORDS_CONFIG}. Each batch is returned as one Flux.
+     * Every record must be acknowledged using ReceiverOffset.acknowledge() in order to commit the offset
+     * corresponding to the record. Acknowledged records are committed based on the configured commit interval
+     * and commit batch size in ReceiverOptions. Records may also be committed manually using ReceiverOffset.commit().
+     *
+     * @return Flux of consumer record batches from Kafka that are committed only after acknowledgement
+     * @since 1.3.21
+     */
+    default Flux<Flux<ReceiverRecord<K, V>>> receiveBatch() {
+        return receiveBatch(null);
     }
 
     /**

--- a/src/test/java/reactor/kafka/AbstractKafkaTest.java
+++ b/src/test/java/reactor/kafka/AbstractKafkaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/AbstractKafkaTest.java
+++ b/src/test/java/reactor/kafka/AbstractKafkaTest.java
@@ -65,7 +65,7 @@ public abstract class AbstractKafkaTest {
 
     public static final int DEFAULT_TEST_TIMEOUT = 60_000;
 
-    private static final KafkaContainer KAFKA = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"))
+    private static final KafkaContainer KAFKA = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
         .withNetwork(null)
         .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
         .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")


### PR DESCRIPTION
This PR is an implementation to resolve #261. I have chosen the name proposed by @serejke [here](https://github.com/reactor/reactor-kafka/issues/261#issuecomment-1011481582) for the new method in KafkaReceiver.

Actually, in our product I use receive() with the bufferTimeout operator. But it is not the best solution to consume a record batch. With the receiveBatch() method batch consumption will be easier.
