### PR TITLE
RePause All Partitions After Rebalance if user paused any and requested

### DIFF
--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -544,6 +544,10 @@ When group management is used, assignment listeners are invoked whenever partiti
 to the consumer after a rebalance operation.  When manual assignment is used, assignment listeners
 are invoked when the consumer is started. Assignment listeners can be used to seek to particular offsets
 in the assigned partitions so that messages are consumed from the specified offset.
+When a user pauses topics/partitions before rebalancing, the behavior depends on the value of
+`pauseAllAfterRebalance`.If it is set to `False`, the paused topics/partitions will remain paused after the rebalance.
+However, if it is set to `True`, all assigned topics/partitions will be paused after the rebalance.
+
 
 When group management is used, revocation listeners are invoked whenever partitions are revoked
 from a consumer after a rebalance operation. When manual assignment is used, revocation listeners

--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -545,9 +545,8 @@ to the consumer after a rebalance operation.  When manual assignment is used, as
 are invoked when the consumer is started. Assignment listeners can be used to seek to particular offsets
 in the assigned partitions so that messages are consumed from the specified offset.
 When a user pauses topics/partitions before rebalancing, the behavior depends on the value of
-`pauseAllAfterRebalance`.If it is set to `False`, the paused topics/partitions will remain paused after the rebalance.
-However, if it is set to `True`, all assigned topics/partitions will be paused after the rebalance.
-
+`pauseAllAfterRebalance`. If it is set to `false`, the paused topics/partitions will remain paused after the rebalance.
+However, if it is set to `true`, all assigned topics/partitions will be paused after the rebalance.
 
 When group management is used, revocation listeners are invoked whenever partitions are revoked
 from a consumer after a rebalance operation. When manual assignment is used, revocation listeners

--- a/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
@@ -66,6 +66,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
     private final Pattern subscribePattern;
     private final Supplier<Scheduler> schedulerSupplier;
     private final ConsumerListener consumerListener;
+    private final Boolean pauseAllAfterRebalance;
 
     ImmutableReceiverOptions() {
         this(new HashMap<>());
@@ -105,6 +106,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
         this.properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         schedulerSupplier = Schedulers::immediate;
         consumerListener = null;
+        pauseAllAfterRebalance = Boolean.FALSE;
     }
 
     ImmutableReceiverOptions(
@@ -127,7 +129,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
         Collection<TopicPartition> partitions,
         Pattern pattern,
         Supplier<Scheduler> supplier,
-        ConsumerListener consumerListener
+        ConsumerListener consumerListener,
+        Boolean pauseAllAfterRebalance
     ) {
         this.properties = new HashMap<>(properties);
         this.assignListeners = new ArrayList<>(assignListeners);
@@ -149,6 +152,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
         this.subscribePattern = pattern;
         this.schedulerSupplier = supplier;
         this.consumerListener = consumerListener;
+        this.pauseAllAfterRebalance = pauseAllAfterRebalance;
     }
 
     @Override
@@ -189,7 +193,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -215,7 +220,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -246,7 +252,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -285,7 +292,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -319,7 +327,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -350,7 +359,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -381,7 +391,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -407,7 +418,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -433,7 +445,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -469,7 +482,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 null,
                 null,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -495,7 +509,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 null,
                 Objects.requireNonNull(pattern),
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -521,7 +536,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 Objects.requireNonNull(partitions),
                 null,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -582,7 +598,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -616,7 +633,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -650,7 +668,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -684,7 +703,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -715,7 +735,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
             assignTopicPartitions,
             subscribePattern,
             schedulerSupplier,
-            consumerListener
+            consumerListener,
+            pauseAllAfterRebalance
         );
     }
 
@@ -746,8 +767,41 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
             );
+    }
+
+    @Override
+    public Boolean pauseAllAfterRebalance() {
+        return this.pauseAllAfterRebalance;
+    }
+
+    @Override
+    public ReceiverOptions<K, V> pauseAllAfterRebalance(Boolean pauseAll) {
+        return new ImmutableReceiverOptions<>(
+            properties,
+            assignListeners,
+            revokeListeners,
+            keyDeserializer,
+            valueDeserializer,
+            pollTimeout,
+            closeTimeout,
+            commitInterval,
+            commitBatchSize,
+            atmostOnceCommitAheadSize,
+            maxCommitAttempts,
+            commitRetryInterval,
+            maxDeferredCommits,
+            maxDelayRebalance,
+            commitIntervalDuringDelay,
+            subscribeTopics,
+            assignTopicPartitions,
+            subscribePattern,
+            schedulerSupplier,
+            consumerListener,
+            pauseAll
+        );
     }
 
     @Override
@@ -776,7 +830,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
             );
     }
 
@@ -807,7 +862,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 Objects.requireNonNull(schedulerSupplier),
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -833,7 +889,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
             assignTopicPartitions,
             subscribePattern,
             schedulerSupplier,
-            consumerListener
+            consumerListener,
+            pauseAllAfterRebalance
         );
     }
 
@@ -858,7 +915,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 assignTopicPartitions,
                 subscribePattern,
                 schedulerSupplier,
-                consumerListener
+                consumerListener,
+                pauseAllAfterRebalance
         );
     }
 
@@ -912,7 +970,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
             subscribeTopics,
             assignTopicPartitions,
             subscribePattern,
-            consumerListener
+            consumerListener,
+            pauseAllAfterRebalance
         );
     }
 
@@ -940,7 +999,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 && Objects.equals(subscribeTopics, that.subscribeTopics)
                 && Objects.equals(assignTopicPartitions, that.assignTopicPartitions)
                 && Objects.equals(subscribePattern, that.subscribePattern)
-                && Objects.equals(consumerListener, that.consumerListener);
+                && Objects.equals(consumerListener, that.consumerListener)
+                && Objects.equals(pauseAllAfterRebalance, that.pauseAllAfterRebalance);
         }
         return false;
     }

--- a/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
@@ -66,7 +66,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
     private final Pattern subscribePattern;
     private final Supplier<Scheduler> schedulerSupplier;
     private final ConsumerListener consumerListener;
-    private final Boolean pauseAllAfterRebalance;
+    private final boolean pauseAllAfterRebalance;
 
     ImmutableReceiverOptions() {
         this(new HashMap<>());
@@ -106,7 +106,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
         this.properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         schedulerSupplier = Schedulers::immediate;
         consumerListener = null;
-        pauseAllAfterRebalance = Boolean.FALSE;
+        pauseAllAfterRebalance = false;
     }
 
     ImmutableReceiverOptions(
@@ -130,7 +130,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
         Pattern pattern,
         Supplier<Scheduler> supplier,
         ConsumerListener consumerListener,
-        Boolean pauseAllAfterRebalance
+        boolean pauseAllAfterRebalance
     ) {
         this.properties = new HashMap<>(properties);
         this.assignListeners = new ArrayList<>(assignListeners);
@@ -773,12 +773,12 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
     }
 
     @Override
-    public Boolean pauseAllAfterRebalance() {
+    public boolean pauseAllAfterRebalance() {
         return this.pauseAllAfterRebalance;
     }
 
     @Override
-    public ReceiverOptions<K, V> pauseAllAfterRebalance(Boolean pauseAll) {
+    public ReceiverOptions<K, V> pauseAllAfterRebalance(boolean pauseAll) {
         return new ImmutableReceiverOptions<>(
             properties,
             assignListeners,
@@ -970,9 +970,8 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
             subscribeTopics,
             assignTopicPartitions,
             subscribePattern,
-            consumerListener,
-            pauseAllAfterRebalance
-        );
+            consumerListener) +
+            (this.pauseAllAfterRebalance ? 1 : 0);
     }
 
     @Override
@@ -1000,7 +999,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
                 && Objects.equals(assignTopicPartitions, that.assignTopicPartitions)
                 && Objects.equals(subscribePattern, that.subscribePattern)
                 && Objects.equals(consumerListener, that.consumerListener)
-                && Objects.equals(pauseAllAfterRebalance, that.pauseAllAfterRebalance);
+                && pauseAllAfterRebalance == that.pauseAllAfterRebalance;
         }
         return false;
     }

--- a/src/main/java/reactor/kafka/receiver/ReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverOptions.java
@@ -271,6 +271,16 @@ public interface ReceiverOptions<K, V> {
     }
 
     /**
+     * When true, pause all partitions on assignment after rebalance,
+     * if any partitions were paused by User before the rebalance. Default false
+     * @param pauseAll
+     * @return
+     */
+    default ReceiverOptions<K, V> pauseAllAfterRebalance(Boolean pauseAll) {
+        return this;
+    }
+
+    /**
      * Set how often to commit offsets, in milliseconds, while a rebalance is being
      * delayed. Default 100ms.
      * @param interval the interval.
@@ -459,6 +469,16 @@ public interface ReceiverOptions<K, V> {
      */
     default Duration maxDelayRebalance() {
         return Duration.ofSeconds(60);
+    }
+
+    /**
+     * When true, pause all partitions on assignment after rebalance,
+     * if any partitions were paused by User before the rebalance.
+     * Default false
+     * @return
+     */
+    default Boolean pauseAllAfterRebalance() {
+        return false;
     }
 
     /**

--- a/src/main/java/reactor/kafka/receiver/ReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverOptions.java
@@ -276,7 +276,7 @@ public interface ReceiverOptions<K, V> {
      * @param pauseAll
      * @return
      */
-    default ReceiverOptions<K, V> pauseAllAfterRebalance(Boolean pauseAll) {
+    default ReceiverOptions<K, V> pauseAllAfterRebalance(boolean pauseAll) {
         return this;
     }
 
@@ -477,7 +477,7 @@ public interface ReceiverOptions<K, V> {
      * Default false
      * @return
      */
-    default Boolean pauseAllAfterRebalance() {
+    default boolean pauseAllAfterRebalance() {
         return false;
     }
 

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
@@ -254,6 +254,9 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
                                     // pause all partitions if any partitions are paused by user before rebalance
                                     log.debug("User requested re-pausing all assignments");
                                     toRepause.addAll(partitions);
+                                    pausedByUser.clear();
+                                    pausedByUser.addAll(partitions);
+
                                 } else {
                                     Iterator<TopicPartition> iterator = pausedByUser.iterator();
                                     while (iterator.hasNext()) {

--- a/src/test/java/reactor/kafka/receiver/internals/PauseRebalanceTests.java
+++ b/src/test/java/reactor/kafka/receiver/internals/PauseRebalanceTests.java
@@ -107,7 +107,6 @@ public class PauseRebalanceTests {
         }).given(consumer).pause(any());
         ReceiverOptions options = ReceiverOptions.create()
                 .subscription(Collections.singleton("topic"));
-     //   ConsumerFactory factory = mock(ConsumerFactory.class);
         given(factory.createConsumer(any())).willReturn(consumer);
         KafkaReceiver receiver = KafkaReceiver.create(factory, options);
         Disposable disposable = receiver.receive()

--- a/src/test/java/reactor/kafka/receiver/internals/PauseRebalanceTests.java
+++ b/src/test/java/reactor/kafka/receiver/internals/PauseRebalanceTests.java
@@ -20,7 +20,6 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
-import org.junit.Before;
 import org.junit.Test;
 import reactor.core.Disposable;
 import reactor.kafka.receiver.KafkaReceiver;
@@ -51,40 +50,23 @@ import static org.mockito.Mockito.verify;
  */
 public class PauseRebalanceTests {
 
-    AtomicBoolean first;
-    AtomicBoolean rebal;
-    AtomicReference<ConsumerRebalanceListener> rebalListener;
-    TopicPartition tp0;
-    TopicPartition tp1;
-    List<TopicPartition> initial;
-    List<TopicPartition> justZero;
-    CountDownLatch consumeLatch;
-    CountDownLatch pauseLatch;
-    CountDownLatch rebalLatch;
-    ConsumerFactory factory = mock(ConsumerFactory.class);
-
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Before
-    public void setup() {
-        first = new AtomicBoolean(true);
-        rebal = new AtomicBoolean();
-        rebalListener = new AtomicReference<>();
-        tp0 = new TopicPartition("topic", 0);
-        tp1 = new TopicPartition("topic", 1);
-        initial = new ArrayList<>();
-        justZero = new ArrayList<>();
-        initial.add(tp0);
-        initial.add(tp1);
-        justZero.add(tp0);
-        consumeLatch = new CountDownLatch(1);
-        pauseLatch = new CountDownLatch(1);
-        rebalLatch = new CountDownLatch(1);
-    }
-
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void testNoResumeOnRebalance() throws Exception {
         Consumer consumer = mock(Consumer.class);
+        AtomicBoolean first = new AtomicBoolean(true);
+        AtomicBoolean rebal = new AtomicBoolean();
+        AtomicReference<ConsumerRebalanceListener> rebalListener = new AtomicReference<>();
+        TopicPartition tp0 = new TopicPartition("topic", 0);
+        TopicPartition tp1 = new TopicPartition("topic", 1);
+        List<TopicPartition> initial = new ArrayList<>();
+        List<TopicPartition> justZero = new ArrayList<>();
+        initial.add(tp0);
+        initial.add(tp1);
+        justZero.add(tp0);
+        CountDownLatch consumeLatch = new CountDownLatch(1);
+        CountDownLatch pauseLatch = new CountDownLatch(1);
+        CountDownLatch rebalLatch = new CountDownLatch(1);
         willAnswer(inv -> {
             rebalListener.set(inv.getArgument(1));
             return null;
@@ -107,6 +89,7 @@ public class PauseRebalanceTests {
         }).given(consumer).pause(any());
         ReceiverOptions options = ReceiverOptions.create()
                 .subscription(Collections.singleton("topic"));
+        ConsumerFactory factory = mock(ConsumerFactory.class);
         given(factory.createConsumer(any())).willReturn(consumer);
         KafkaReceiver receiver = KafkaReceiver.create(factory, options);
         Disposable disposable = receiver.receive()
@@ -129,6 +112,19 @@ public class PauseRebalanceTests {
     @Test
     public void testPauseAllAfterRebalance() throws Exception {
         Consumer consumer = mock(Consumer.class);
+        AtomicBoolean first = new AtomicBoolean(true);
+        AtomicBoolean rebal = new AtomicBoolean();
+        AtomicReference<ConsumerRebalanceListener> rebalListener = new AtomicReference<>();
+        TopicPartition tp0 = new TopicPartition("topic", 0);
+        TopicPartition tp1 = new TopicPartition("topic", 1);
+        List<TopicPartition> initial = new ArrayList<>();
+        List<TopicPartition> afterRebal = new ArrayList<>();
+        initial.add(tp0);
+        afterRebal.add(tp0);
+        afterRebal.add(tp1);
+        CountDownLatch consumeLatch = new CountDownLatch(1);
+        CountDownLatch pauseLatch = new CountDownLatch(1);
+        CountDownLatch rebalLatch = new CountDownLatch(1);
         willAnswer(inv -> {
             rebalListener.set(inv.getArgument(1));
             return null;
@@ -140,7 +136,7 @@ public class PauseRebalanceTests {
             }
             if (rebal.getAndSet(false)) {
                 rebalListener.get().onPartitionsRevoked(initial);
-                rebalListener.get().onPartitionsAssigned(Collections.singletonList(tp0));
+                rebalListener.get().onPartitionsAssigned(afterRebal);
                 rebalLatch.countDown();
             }
             return ConsumerRecords.empty();
@@ -149,7 +145,7 @@ public class PauseRebalanceTests {
             pauseLatch.countDown();
             return null;
         }).given(consumer).pause(any());
-
+        ConsumerFactory factory = mock(ConsumerFactory.class);
         ReceiverOptions options = ReceiverOptions.create().pauseAllAfterRebalance(Boolean.TRUE)
             .subscription(Collections.singleton("topic"));
 
@@ -166,11 +162,9 @@ public class PauseRebalanceTests {
         checkUserPauses(receiver, initial);
         rebal.set(true);
         assertTrue(rebalLatch.await(10, TimeUnit.SECONDS));
-        //all paused after rebalance
-        verify(consumer).pause(initial);
-        Collection<TopicPartition> expected = new ArrayList<>();
-        expected.addAll(initial);
-        checkUserPauses(receiver, expected);
+
+        verify(consumer).pause(afterRebal);
+        checkUserPauses(receiver, afterRebal);
         disposable.dispose();
     }
 

--- a/src/test/java/reactor/kafka/receiver/internals/PauseRebalanceTests.java
+++ b/src/test/java/reactor/kafka/receiver/internals/PauseRebalanceTests.java
@@ -36,6 +36,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -146,9 +148,18 @@ public class PauseRebalanceTests {
             return null;
         }).given(consumer).pause(any());
         ConsumerFactory factory = mock(ConsumerFactory.class);
-        ReceiverOptions options = ReceiverOptions.create().pauseAllAfterRebalance(Boolean.TRUE)
-            .subscription(Collections.singleton("topic"));
 
+        ReceiverOptions options1 = ReceiverOptions.create().pauseAllAfterRebalance(false)
+            .subscription(Collections.singleton("topic"));
+        ReceiverOptions options2 = ReceiverOptions.create()
+            .subscription(Collections.singleton("topic"));
+        assertTrue(options1.equals(options2));
+        assertEquals(options1.hashCode(), options2.hashCode());
+
+        ReceiverOptions options = ReceiverOptions.create().pauseAllAfterRebalance(true)
+            .subscription(Collections.singleton("topic"));
+        assertTrue(options.hashCode() - options1.hashCode() == 1);
+        assertFalse(options1.equals(options));
         given(factory.createConsumer(any())).willReturn(consumer);
         KafkaReceiver receiver = KafkaReceiver.create(factory, options);
         Disposable disposable = receiver.receive()


### PR DESCRIPTION
Resolves [#307](https://github.com/reactor/reactor-kafka/issues/307)

In order to achieve graceful shutdown during deployment, We applied the following strategy:
1. Pause old kafka consumer
2. Process in-flight messages
3. Application fully shutdown.
But when new consumers join the consumer group, after rebalance, old consumers wake up, if the newly assigned partitions are not in the pausedByUser, consumer start poll messages which gracefully shutdown are not fully achieved. 

Add pauseAllAfterRebalance configuration
When a user pauses topics/partitions before rebalancing, the behavior depends on the value of pauseAllAfterRebalance.If it is set to False, the paused topics/partitions will remain paused after the rebalance. However, if it is set to True, all assigned topics/partitions will be paused after the rebalance.

Test:
ReceiverOptions.create(props).pauseAllAfterRebalance(Boolean.TRUE);

Consumer-1 assigned partitions: testTopic-2
Consumer-2 assigned partitions: testTopic-0, testTopic3-1

Consumer-2 Pause Topic/Partitions
Kafka Consumer Template status=PAUSE topic=testTopic, partition=0
Kafka Consumer Template status=PAUSE topic=testTopic, partition=1

Consumer-3 join - rebalance
Consumer-2 Revoke previously assigned partitions testTopic-0, testTopic-1
                      Assignment(partitions=[testTopic-2])}

testTopic-2 paused.