### PR TITLE
Draft for an exactly once processor with support for horizontal scaling

### DIFF
--- a/src/main/java/reactor/kafka/receiver/ExactlyOnceProcessor.java
+++ b/src/main/java/reactor/kafka/receiver/ExactlyOnceProcessor.java
@@ -1,0 +1,24 @@
+package reactor.kafka.receiver;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.kafka.receiver.internals.DefaultExactlyOnceProcessor;
+import reactor.kafka.sender.SenderOptions;
+import reactor.kafka.sender.SenderRecord;
+import reactor.kafka.sender.SenderResult;
+
+import java.util.function.Function;
+
+public interface ExactlyOnceProcessor<K, V, SK, SV> {
+
+    static <K, V, SK, SV> ExactlyOnceProcessor<K, V, SK, SV> create(ReceiverOptions<K, V> receiverOptions, SenderOptions<SK, SV> senderOptions) {
+        return new DefaultExactlyOnceProcessor<>("", receiverOptions, senderOptions);
+    }
+
+    static <K, V, SK, SV> ExactlyOnceProcessor<K, V, SK, SV> create(String transactionalIdPrefix, ReceiverOptions<K, V> receiverOptions, SenderOptions<SK, SV> senderOptions) {
+        return new DefaultExactlyOnceProcessor<>(transactionalIdPrefix, receiverOptions, senderOptions);
+    }
+
+    public Flux<SenderResult<SK>> processExactlyOnce(Function<ReceiverRecord<K, V>, ? extends Publisher<SenderRecord<SK, SV, SK>>> processor);
+
+}

--- a/src/main/java/reactor/kafka/receiver/internals/DefaultExactlyOnceProcessor.java
+++ b/src/main/java/reactor/kafka/receiver/internals/DefaultExactlyOnceProcessor.java
@@ -7,6 +7,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.kafka.receiver.ExactlyOnceProcessor;
 import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.receiver.ReceiverOptions;
 import reactor.kafka.receiver.ReceiverPartition;
@@ -22,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-public class DefaultExactlyOnceProcessor<K, V, SK, SV> {
+public class DefaultExactlyOnceProcessor<K, V, SK, SV> implements ExactlyOnceProcessor<K, V, SK, SV> {
 
     private final KafkaReceiver<K, V> receiver;
     private final Map<TopicPartition, KafkaSender<SK, SV>> sendersForPartions;

--- a/src/main/java/reactor/kafka/receiver/internals/DefaultExactlyOnceProcessor.java
+++ b/src/main/java/reactor/kafka/receiver/internals/DefaultExactlyOnceProcessor.java
@@ -1,0 +1,65 @@
+package reactor.kafka.receiver.internals;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.kafka.receiver.KafkaReceiver;
+import reactor.kafka.receiver.ReceiverOptions;
+import reactor.kafka.receiver.ReceiverPartition;
+import reactor.kafka.receiver.ReceiverRecord;
+import reactor.kafka.sender.KafkaSender;
+import reactor.kafka.sender.SenderOptions;
+import reactor.kafka.sender.SenderRecord;
+import reactor.kafka.sender.SenderResult;
+import reactor.util.function.Tuple2;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class DefaultExactlyOnceProcessor<K, V, SK, SV> {
+
+    private final KafkaReceiver<K, V> receiver;
+    private final Map<TopicPartition, KafkaSender<SK, SV>> sendersForPartions;
+
+    public DefaultExactlyOnceProcessor(ReceiverOptions<K, V> receiverOptions, SenderOptions<SK, SV> senderOptions) {
+        this.sendersForPartions = new HashMap<>();
+        // TODO: Append existing listeners
+        receiverOptions.addRevokeListener(
+            receiverPartitions -> receiverPartitions.stream().map(ReceiverPartition::topicPartition).forEach(sendersForPartions::remove));
+        receiverOptions.addAssignListener(
+            receiverPartitions -> receiverPartitions.stream().map(ReceiverPartition::topicPartition).forEach(topicPartition -> {
+                SenderOptions<SK, SV> localSenderOptions = senderOptions.producerProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG,
+                    topicPartition.toString());
+
+                sendersForPartions.put(topicPartition, KafkaSender.create(localSenderOptions));
+            }));
+
+        this.receiver = KafkaReceiver.create(receiverOptions);
+    }
+
+    public Flux<SenderResult<SK>> processExactlyOnce(Function<ReceiverRecord<K, V>, ? extends Publisher<SenderRecord<SK, SV, SK>>> processor) {
+        return receiver.doOnConsumer(Consumer::groupMetadata)
+            .flatMapMany(groupMetadata -> receiver.receiveBatch()
+                .flatMap(batch -> batch.groupBy(receiverRecord -> receiverRecord.receiverOffset().topicPartition()))
+                .flatMap(groupedBatch -> groupedBatch.collectList().flatMapMany(receiverRecords -> {
+                    CommittableBatch offsetBatch = new CommittableBatch();
+                    for (ConsumerRecord<K, V> r : receiverRecords) {
+                        offsetBatch.updateOffset(groupedBatch.key(), r.offset());
+                    }
+                    KafkaSender<SK, SV> batchSender = sendersForPartions.get(groupedBatch.key());
+
+                    return batchSender.send(batchSender.transactionManager()
+                        .begin()
+                        .thenMany(Flux.defer(() -> Flux.fromIterable(receiverRecords)))
+                        .concatWith(batchSender.transactionManager().sendOffsets(offsetBatch.getAndClearOffsets().offsets(), groupMetadata))
+                        .flatMap(processor)).concatWith(batchSender.transactionManager().commit()).onErrorResume(e -> {
+                        return batchSender.transactionManager().abort().then(Mono.error(e));
+                    });
+                })));
+    }
+}


### PR DESCRIPTION
As I understand it, for exactly once Zombie Fencing to function correctly with horizontally scaled processors, it has to be ensured that the Sender with the same transactionalId always consumes from the same inbound topic partitions. 

As the transactionalId has to be unique, I thought it might be a good idea, to create a Sender for each assigned Inbound Topic and have the TopicPartition be part of the Senders transactionalId. I read somewhere that Spring Kafka does it that way.  

I wanted to put my first (naive) implementation of this up for discussion, to see if I'm on the right track and if this is a feature that might be integrated into Reactor-Kafka.

Obviously, it still need refactoring and tests. But I wanted to discuss if I'm on the right track before moving further. 

Thank you for your consideration.