### PR TITLE
GH-333: Support currentLag() in doOnConsumer

### DIFF
--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
@@ -65,7 +65,8 @@ class ConsumerHandler<K, V> {
         "resume",
         "offsetsForTimes",
         "beginningOffsets",
-        "endOffsets"
+        "endOffsets",
+        "currentLag"
     ));
 
     private static final AtomicInteger COUNTER = new AtomicInteger();


### PR DESCRIPTION
Resolves https://github.com/reactor/reactor-kafka/issues/333