### PR TITLE
Fix broken example code ('retry(When' -> 'retryWhen')

### DIFF
--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -334,8 +334,8 @@ which will ensure that a new consumer is created:
 --------
 Flux<ReceiverRecord<Integer, String>> inboundFlux =
     KafkaReceiver.create(receiverOptions)
-                 .receive()
-                 .retry(When(Retry.backoff(3, Duration.of(10L, ChronoUnit.SECONDS))));
+        .receive()
+        .retryWhen(Retry.backoff(3, Duration.of(10L, ChronoUnit.SECONDS)));
 --------
 
 Any errors related to the event processing rather than the `KafkaConsumer` itself should be handled as close to the source as possible

--- a/src/docs/asciidoc/examples.adoc
+++ b/src/docs/asciidoc/examples.adoc
@@ -72,7 +72,7 @@ KafkaSender.create(senderOptions)
            .send(source.flux().map(r -> transform(r)))                      // <4>
            .doOnError(e-> log.error("Send failed, terminating.", e))        // <5>
            .doOnNext(r -> source.commit(r.correlationMetadata()))           // <6>
-           .retry(When(Retry.backoff(3, Duration.of(10L, ChronoUnit.SECONDS))));
+           .retryWhen(Retry.backoff(3, Duration.of(10L, ChronoUnit.SECONDS)));
 --------
 <1> Send is acknowledged by Kafka for acks=all after message is delivered to all in-sync replicas
 <2> Large number of retries in the producer to cope with transient failures in brokers
@@ -100,7 +100,7 @@ KafkaReceiver.create(receiverOptions)
              .publishOn(aBoundedElasticScheduler) // <4>
              .concatMap(m -> sink.store(transform(m))                                   // <5>
                                .doOnSuccess(r -> m.receiverOffset().commit().block()))  // <6>
-             .retry(When(Retry.backoff(3, Duration.of(10L, ChronoUnit.SECONDS))))
+             .retryWhen(Retry.backoff(3, Duration.of(10L, ChronoUnit.SECONDS)));
 --------
 <1> Disable periodic commits
 <2> Disable commits by batch size


### PR DESCRIPTION
It seems example code is broken.

![Screenshot 2023-10-26 at 5 24 19 PM](https://github.com/reactor/reactor-kafka/assets/24649991/d17096e0-ed14-4902-b210-2f029c00facc)
