### PR TITLE
Expose manual stop method in KafkaReceiver

### DIFF
--- a/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
+++ b/src/main/java/reactor/kafka/receiver/KafkaReceiver.java
@@ -283,4 +283,12 @@ public interface KafkaReceiver<K, V> {
      * @return Mono that completes with the value returned by <code>function</code>
      */
     <T> Mono<T> doOnConsumer(Function<Consumer<K, V>, ? extends T> function);
+
+    /**
+     * Explicitly shutdowns this {@link KafkaReceiver} and underlying Kafka {@link Consumer} asynchronously.
+     * Invoking this method initiates to stop fetching records from Kafka {@link Consumer} and emit completion signal downstream.
+     *
+     * @return Mono that stop current {@link KafkaReceiver}
+     */
+    Mono<Void> stop();
 }

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
@@ -215,7 +215,8 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
 
                 this.consumer.wakeup();
                 return Mono.<Void>fromRunnable(new CloseEvent(receiverOptions.closeTimeout()))
-                    .as(flux -> flux.subscribeOn(eventScheduler));
+                    .as(flux -> flux.subscribeOn(eventScheduler))
+                    .doOnTerminate(() -> sink.emitComplete(ConsumerEventLoop.this));
             })
             .onErrorResume(e -> {
                 log.warn("Cancel exception: " + e);

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
@@ -20,8 +20,6 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerHandler.java
@@ -49,9 +49,6 @@ import java.util.function.Predicate;
  * To be exposed as a public class in the next major version (a subject to the API review).
  */
 class ConsumerHandler<K, V> {
-
-    private static final Logger log = LoggerFactory.getLogger(ConsumerHandler.class);
-
     /** Note: Methods added to this set should also be included in javadoc for {@link KafkaReceiver#doOnConsumer(Function)} */
     private static final Set<String> DELEGATE_METHODS = new HashSet<>(Arrays.asList(
         "assignment",

--- a/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
@@ -1538,7 +1538,7 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
         return disposable;
     }
 
-    private void waitFoPartitionAssignment() throws InterruptedException { // todo : typo
+    private void waitFoPartitionAssignment() throws InterruptedException {
         assertTrue("Partitions not assigned", assignSemaphore.tryAcquire(sessionTimeoutMillis + 1000, TimeUnit.MILLISECONDS));
     }
 

--- a/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/KafkaReceiverTest.java
@@ -1511,7 +1511,7 @@ public class KafkaReceiverTest extends AbstractKafkaTest {
         return disposable;
     }
 
-    private void waitFoPartitionAssignment() throws InterruptedException {
+    private void waitFoPartitionAssignment() throws InterruptedException { // todo : typo
         assertTrue("Partitions not assigned", assignSemaphore.tryAcquire(sessionTimeoutMillis + 1000, TimeUnit.MILLISECONDS));
     }
 


### PR DESCRIPTION
KafkaReceiver currently is not possible to close safely. An example is below:

```kotlin
val disposable = kafkaReceiver.receive()
    .flatMapSequential { record -> process(record).then(record) }
    .delayUntil { 
        it.receiverOffset().acknowledge() 
        it.receiverOffset().commit()
}
    .subscribe()
```

`dispose()` method would be a way,  but it might lead to unexpected result because of cancellation leading processed records not to be committed. I think This PR is discussed at #247, and also helps to address #378 indirectly.(People can customize KafkaReceiver's lifecycle after stopping followed by `disposable.isDisposed()`

I've considered several situations related to thread-safety or something, but might miss I didn't expect. Any further suggestions would be appreciated.