### PR TITLE
GH-395: Add Dependabot support to the project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,91 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+      day: sunday
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+    open-pull-requests-limit: 10
+    labels:
+      - 'type: dependency-upgrade'
+    groups:
+       development-dependencies:
+         update-types:
+          - patch
+         patterns:
+           - com.gradle*
+           - org.asciidoctor*
+           - com.jfrog.artifactory
+           - com.diffplug.spotless
+           - org.powermock*
+           - org.awaitility:awaitility
+           - org.testcontainers*
+           - com.google.code.findbugs:jsr305
+           - junit:junit
+           - org.assertj:assertj-core
+           - org.apache.logging.log4j*
+           - org.slf4j:slf4j-api
+           - io.micrometer:micrometer-tracing-integration-test
+
+  - package-ecosystem: gradle
+    target-branch: 1.3.x
+    directory: /
+    schedule:
+      interval: weekly
+      day: sunday
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+    open-pull-requests-limit: 10
+    labels:
+      - 'type: dependency-upgrade'
+    groups:
+      development-dependencies:
+        update-types:
+          - patch
+        patterns:
+          - com.gradle*
+          - org.asciidoctor*
+          - com.jfrog.artifactory
+          - com.diffplug.spotless
+          - org.powermock*
+          - org.awaitility:awaitility
+          - org.testcontainers*
+          - com.google.code.findbugs:jsr305
+          - junit:junit
+          - org.assertj:assertj-core
+          - org.apache.logging.log4j*
+          - org.slf4j:slf4j-api
+          - io.micrometer:micrometer-tracing-integration-test
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: sunday
+    labels:
+      - 'type: task'
+    groups:
+      development-dependencies:
+        patterns:
+          - '*'
+
+  - package-ecosystem: github-actions
+    target-branch: 1.3.x
+    directory: /
+    schedule:
+      interval: weekly
+      day: sunday
+    labels:
+      - 'type: task'
+    groups:
+      development-dependencies:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,51 +1,20 @@
 version: 2
 updates:
   - package-ecosystem: gradle
-    directory: /
-    schedule:
-      interval: weekly
-      day: sunday
-    ignore:
-      - dependency-name: '*'
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
-    open-pull-requests-limit: 10
-    labels:
-      - 'type: dependency-upgrade'
-    groups:
-       development-dependencies:
-         update-types:
-          - patch
-         patterns:
-           - com.gradle*
-           - org.asciidoctor*
-           - com.jfrog.artifactory
-           - com.diffplug.spotless
-           - org.powermock*
-           - org.awaitility:awaitility
-           - org.testcontainers*
-           - com.google.code.findbugs:jsr305
-           - junit:junit
-           - org.assertj:assertj-core
-           - org.apache.logging.log4j*
-           - org.slf4j:slf4j-api
-           - io.micrometer:micrometer-tracing-integration-test
-
-  - package-ecosystem: gradle
     target-branch: 1.3.x
     directory: /
     schedule:
       interval: weekly
       day: sunday
     ignore:
+      - dependency-name: com.google.code.findbugs:jsr305
       - dependency-name: '*'
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
     open-pull-requests-limit: 10
     labels:
-      - 'type: dependency-upgrade'
+      - 'type/dependency-upgrade'
     groups:
       development-dependencies:
         update-types:
@@ -58,24 +27,11 @@ updates:
           - org.powermock*
           - org.awaitility:awaitility
           - org.testcontainers*
-          - com.google.code.findbugs:jsr305
           - junit:junit
           - org.assertj:assertj-core
           - org.apache.logging.log4j*
           - org.slf4j:slf4j-api
           - io.micrometer:micrometer-tracing-integration-test
-
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-      day: sunday
-    labels:
-      - 'type: task'
-    groups:
-      development-dependencies:
-        patterns:
-          - '*'
 
   - package-ecosystem: github-actions
     target-branch: 1.3.x
@@ -84,7 +40,7 @@ updates:
       interval: weekly
       day: sunday
     labels:
-      - 'type: task'
+      - 'type/task'
     groups:
       development-dependencies:
         patterns:


### PR DESCRIPTION
Fixes: #395
Issue link: https://github.com/reactor/reactor-kafka/issues/395

* Added `dependabot.yml` config for both `main` and `1.3.x` supported branches
* Include updates of `package-ecosystem` for Gradle and GitHub Actions
* Extract `development-dependencies` group for those dependencies which are used only for this project development: all the test dependencies, `compileOnly` and Gradle plugins

Note: had to rename label in project repository to the `type: dependency-upgrade` and also added `type: task`