### PR TITLE
Regroup Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,6 @@ updates:
       day: sunday
     ignore:
       - dependency-name: '*'
-    open-pull-requests-limit: 10
     labels:
       - 'type/chores'
     groups:
@@ -34,19 +33,12 @@ updates:
         update-types:
           - patch
         patterns:
-          - com.gradle*
-          - org.asciidoctor*
-          - com.jfrog.artifactory
-          - com.diffplug.spotless
-          - org.powermock*
-          - org.awaitility:awaitility
-          - org.testcontainers*
-          - junit:junit
-          - org.assertj:assertj-core
-          - org.apache.logging.log4j*
-          - org.slf4j:slf4j-api
-          - io.micrometer:micrometer-tracing-integration-test
-          - io.projectreactor*
+          - *
+        exclude-patterns:
+          - org.apache.kafka*
+          - io.micrometer:micrometer-core
+          - io.micrometer:micrometer-observation
+          - com.google.code.findbugs:jsr305
 
   - package-ecosystem: github-actions
     target-branch: 1.3.x

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,10 @@ updates:
     schedule:
       interval: weekly
       day: sunday
+    allow:
+      - dependency-name: org.apache.kafka:kafka-clients
+      - dependency-name: io.micrometer:micrometer-core
     ignore:
-      - dependency-name: com.google.code.findbugs:jsr305
       - dependency-name: '*'
         update-types:
           - version-update:semver-major
@@ -15,6 +17,18 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - 'type/dependency-upgrade'
+
+  - package-ecosystem: gradle
+    target-branch: 1.3.x
+    directory: /
+    schedule:
+      interval: weekly
+      day: sunday
+    ignore:
+      - dependency-name: '*'
+    open-pull-requests-limit: 10
+    labels:
+      - 'type/chores'
     groups:
       development-dependencies:
         update-types:
@@ -32,6 +46,7 @@ updates:
           - org.apache.logging.log4j*
           - org.slf4j:slf4j-api
           - io.micrometer:micrometer-tracing-integration-test
+          - io.projectreactor*
 
   - package-ecosystem: github-actions
     target-branch: 1.3.x
@@ -40,7 +55,7 @@ updates:
       interval: weekly
       day: sunday
     labels:
-      - 'type/task'
+      - 'type/chores'
     groups:
       development-dependencies:
         patterns:


### PR DESCRIPTION
* Kafka and Micrometer deps as `type/dependency-upgrade`
* All other as `type/chores`