### PR TITLE
NVM 

### DIFF
--- a/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
+++ b/src/main/java/reactor/kafka/receiver/ImmutableReceiverOptions.java
@@ -724,7 +724,7 @@ class ImmutableReceiverOptions<K, V> implements ReceiverOptions<K, V> {
     @Override
     public ReceiverOptions<K, V> maxCommitAttempts(int maxAttempts) {
         if (maxAttempts < 0)
-            throw new IllegalArgumentException("the number of attempts must be >= 0");
+            throw new IllegalArgumentException("the number of attempts must be > 0");
 
         return new ImmutableReceiverOptions<>(
                 properties,


### PR DESCRIPTION
This fixes a wrong error message because the `maxCommitAttempts` can not be `0` it can only be greater than that.