### PR TITLE
GH-421: Fix behavior of undoCommitAhead

### DIFF
--- a/src/main/java/reactor/kafka/receiver/internals/AtmostOnceOffsets.java
+++ b/src/main/java/reactor/kafka/receiver/internals/AtmostOnceOffsets.java
@@ -19,6 +19,7 @@ package reactor.kafka.receiver.internals;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -51,5 +52,11 @@ class AtmostOnceOffsets {
             }
         }
         return undoRequired;
+    }
+
+    // The consumer shouldn't commit offsets for partitions that aren't assigned to it
+    // as this might break processing guarantees for other consumers.
+    void partitionsRevoked(Collection<TopicPartition> partitions) {
+        partitions.forEach(committedOffsets::remove);
     }
 }

--- a/src/main/java/reactor/kafka/receiver/internals/AtmostOnceOffsets.java
+++ b/src/main/java/reactor/kafka/receiver/internals/AtmostOnceOffsets.java
@@ -44,7 +44,7 @@ class AtmostOnceOffsets {
         boolean undoRequired = false;
         for (Map.Entry<TopicPartition, Long> entry : committedOffsets.entrySet()) {
             TopicPartition topicPartition = entry.getKey();
-            long offsetToCommit = dispatchedOffsets.get(entry.getKey()) + 1;
+            long offsetToCommit = dispatchedOffsets.get(entry.getKey());
             if (entry.getValue() > offsetToCommit) {
                 committableBatch.updateOffset(topicPartition, offsetToCommit);
                 undoRequired = true;

--- a/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
+++ b/src/main/java/reactor/kafka/receiver/internals/ConsumerEventLoop.java
@@ -295,6 +295,9 @@ class ConsumerEventLoop<K, V> implements Sinks.EmitFailureHandler {
                         public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
                             ConsumerEventLoop.this.onPartitionsRevoked(partitions);
                             ConsumerEventLoop.this.pollEvent.commitBatch.partitionsRevoked(partitions);
+                            if (ConsumerEventLoop.this.atmostOnceOffsets != null) {
+                                ConsumerEventLoop.this.atmostOnceOffsets.partitionsRevoked(partitions);
+                            }
                         }
                     })
                     .accept(consumer);

--- a/src/test/java/reactor/kafka/mock/MockConsumer.java
+++ b/src/test/java/reactor/kafka/mock/MockConsumer.java
@@ -162,6 +162,7 @@ public class MockConsumer extends org.apache.kafka.clients.consumer.MockConsumer
                 }
             }
             assignmentPending = true;
+            super.subscribe(topics, callback);
         } finally {
             release();
         }

--- a/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
@@ -369,7 +369,7 @@ public class MockReceiverTest {
      * Tests {@link KafkaReceiver#receiveAtmostOnce()} with commit-ahead.
      */
     @Test
-    public void atmostOnceCommitAheadSize() {
+    public void atmostOnceCommitAheadSize() throws InterruptedException {
         int commitAhead = 5;
         receiverOptions = receiverOptions
                 .atmostOnceCommitAheadSize(commitAhead)
@@ -387,6 +387,7 @@ public class MockReceiverTest {
             .thenCancel()
             .verify(Duration.ofMillis(DEFAULT_TEST_TIMEOUT));
         verifyMessages(consumeCount);
+        waitForConsumerToClose();
         verifyUndoCommitAhead(consumedOffsets);
     }
 
@@ -416,7 +417,7 @@ public class MockReceiverTest {
      * Tests if commit-ahead doesn't break offsets for partitions that have been revoked from the consumer.
      */
     @Test
-    public void atmostOnceUndoCommitAhead() {
+    public void atmostOnceUndoCommitAhead() throws InterruptedException {
         int commitAhead = 5;
         List<TopicPartition> initialPartitions = new ArrayList<>(cluster.partitions(topic));
         receiverOptions = receiverOptions
@@ -436,6 +437,7 @@ public class MockReceiverTest {
             .thenCancel()
             .verify(Duration.ofMillis(DEFAULT_TEST_TIMEOUT));
         verifyMessages(consumeCount);
+        waitForConsumerToClose();
         verifyNoMoreCommitsOn(partition.get());
     }
 
@@ -1566,6 +1568,12 @@ public class MockReceiverTest {
 
     private TopicPartition topicPartition(ConsumerRecord<?, ?> record) {
         return new TopicPartition(record.topic(), record.partition());
+    }
+
+    private void waitForConsumerToClose() throws InterruptedException {
+        while (!consumer.closed()) {
+            Thread.sleep(100);
+        }
     }
 
     private static class ParitionWithOffset {

--- a/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
@@ -66,6 +66,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -411,6 +412,48 @@ public class MockReceiverTest {
         });
     }
 
+    /**
+     * Tests if commit-ahead doesn't break offsets for partitions that have been revoked from the consumer.
+     */
+    @Test
+    public void atmostOnceUndoCommitAhead() {
+        int commitAhead = 5;
+        List<TopicPartition> initialPartitions = new ArrayList<>(cluster.partitions(topic));
+        receiverOptions = receiverOptions
+            .atmostOnceCommitAheadSize(commitAhead)
+            .subscription(Collections.singleton(topic));
+        sendMessages(topic, 0, 2);
+        Flux<ConsumerRecord<Integer, String>> inboundFlux = new DefaultKafkaReceiver<>(consumerFactory, receiverOptions)
+            .receiveAtmostOnce();
+
+        int consumeCount = 2;
+        AtomicReference<ParitionWithOffset> partition = new AtomicReference<>();
+        StepVerifier.create(inboundFlux, consumeCount)
+            .recordWith(() -> receivedMessages)
+            .then(() -> consumer.rebalance(initialPartitions))
+            .expectNextCount(consumeCount)
+            .then(() -> revokeAndRegisterPartition(initialPartitions, partition))
+            .thenCancel()
+            .verify(Duration.ofMillis(DEFAULT_TEST_TIMEOUT));
+        verifyMessages(consumeCount);
+        verifyNoMoreCommitsOn(partition.get());
+    }
+
+    private void revokeAndRegisterPartition(
+        List<TopicPartition> initialPartitions,
+        AtomicReference<ParitionWithOffset> revokedPartitionRef
+    ) {
+        List<TopicPartition> newPartitions = initialPartitions.subList(1, initialPartitions.size());
+        TopicPartition revokedPartition = initialPartitions.get(0);
+        long commitAheadOffset = cluster.committedOffset(consumer.groupMetadata().groupId(), revokedPartition);
+        revokedPartitionRef.set(new ParitionWithOffset(revokedPartition, commitAheadOffset));
+        consumer.rebalance(newPartitions);
+    }
+
+    private void verifyNoMoreCommitsOn(ParitionWithOffset revokedPartition) {
+        long lastCommittedOffset = cluster.committedOffset(consumer.groupMetadata().groupId(), revokedPartition.partition);
+        assertEquals("Consumer committed on partition that was revoked", lastCommittedOffset, revokedPartition.offset);
+    }
 
     /**
      * Tests that transient commit failures are retried with {@link KafkaReceiver#receiveAtmostOnce()}.
@@ -1523,5 +1566,15 @@ public class MockReceiverTest {
 
     private TopicPartition topicPartition(ConsumerRecord<?, ?> record) {
         return new TopicPartition(record.topic(), record.partition());
+    }
+
+    private static class ParitionWithOffset {
+        private final TopicPartition partition;
+        private final long offset;
+
+        public ParitionWithOffset(TopicPartition partition, long offset) {
+            this.partition = partition;
+            this.offset = offset;
+        }
     }
 }

--- a/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
@@ -377,32 +377,40 @@ public class MockReceiverTest {
         Map<TopicPartition, Long> consumedOffsets = new HashMap<>();
         Flux<ConsumerRecord<Integer, String>> inboundFlux = new DefaultKafkaReceiver<>(consumerFactory, receiverOptions)
                 .receiveAtmostOnce()
-                .filter(r -> {
-                    long committed = cluster.committedOffset(groupId, topicPartition(r));
-                    return committed >= r.offset() && committed <= r.offset() + commitAhead + 1;
-                })
                 .doOnNext(r -> consumedOffsets.put(new TopicPartition(r.topic(), r.partition()), r.offset()));
         int consumeCount = 17;
         StepVerifier.create(inboundFlux, consumeCount)
             .recordWith(() -> receivedMessages)
             .expectNextCount(consumeCount)
+            .expectRecordedMatches(ignored -> verifyCommittedAhead(consumedOffsets, commitAhead))
             .thenCancel()
             .verify(Duration.ofMillis(DEFAULT_TEST_TIMEOUT));
         verifyMessages(consumeCount);
-        for (int i = 0; i < cluster.partitions(topic).size(); i++) {
-            TopicPartition topicPartition = new TopicPartition(topic, i);
+        verifyUndoCommitAhead(consumedOffsets);
+    }
+
+    private boolean verifyCommittedAhead(Map<TopicPartition, Long> consumedOffsets, int commitAhead) {
+        return cluster.partitions(topic).stream().allMatch(topicPartition -> {
+            long consumed = consumedOffsets.get(topicPartition);
+            long committedOffset = cluster.committedOffset(groupId, topicPartition);
+            return committedOffset > consumed && committedOffset <= consumed + commitAhead + 1;
+        });
+    }
+
+    private void verifyUndoCommitAhead(Map<TopicPartition, Long> consumedOffsets) {
+        cluster.partitions(topic).forEach(topicPartition -> {
             long consumed = consumedOffsets.get(topicPartition);
             consumerFactory.addConsumer(new MockConsumer(cluster));
             receiverOptions = receiverOptions.assignment(Collections.singleton(topicPartition));
-            inboundFlux = new DefaultKafkaReceiver<>(consumerFactory, receiverOptions)
+            Flux<ConsumerRecord<Integer, String>> inboundFlux = new DefaultKafkaReceiver<>(consumerFactory, receiverOptions)
                     .receiveAtmostOnce();
             StepVerifier.create(inboundFlux, 1)
-                .expectNextMatches(r -> r.offset() > consumed && r.offset() <= consumed + commitAhead + 1)
+                .expectNextMatches(r -> r.offset() == consumed + 1)
                 .thenCancel()
                 .verify(Duration.ofMillis(DEFAULT_TEST_TIMEOUT));
-        }
-
+        });
     }
+
 
     /**
      * Tests that transient commit failures are retried with {@link KafkaReceiver#receiveAtmostOnce()}.


### PR DESCRIPTION
Related to https://github.com/reactor/reactor-kafka/issues/421.

Proposed changeset:
1. Clear state of revoked partitions in `AtmostOnceOffsets`
2. Correct off-by-one error in offsets committed after `undoCommitAhead`