### PR TITLE
fix: bump kafka-clients version to 4.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ reactiveStreams = "1.0.3"
 micrometerTracing = '1.1.4'
 
 [libraries]
-kafka = "org.apache.kafka:kafka-clients:3.9.0"
+kafka = "org.apache.kafka:kafka-clients:4.0.0"
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactorCore" }
 reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "reactorCore" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ reactiveStreams = "1.0.3"
 micrometerTracing = '1.1.4'
 
 [libraries]
-kafka = "org.apache.kafka:kafka-clients:3.6.0"
+kafka = "org.apache.kafka:kafka-clients:3.9.0"
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactorCore" }
 reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "reactorCore" }
 

--- a/src/main/java/reactor/kafka/receiver/ReceiverRecord.java
+++ b/src/main/java/reactor/kafka/receiver/ReceiverRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,12 +50,12 @@ public class ReceiverRecord<K, V> extends ConsumerRecord<K, V> {
                 consumerRecord.offset(),
                 consumerRecord.timestamp(),
                 consumerRecord.timestampType(),
-                checksum(consumerRecord),
                 consumerRecord.serializedKeySize(),
                 consumerRecord.serializedValueSize(),
                 consumerRecord.key(),
                 consumerRecord.value(),
-                consumerRecord.headers());
+                consumerRecord.headers(),
+            consumerRecord.leaderEpoch());
         this.receiverOffset = receiverOffset;
     }
 

--- a/src/main/java/reactor/kafka/sender/internals/DefaultTransactionManager.java
+++ b/src/main/java/reactor/kafka/sender/internals/DefaultTransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ class DefaultTransactionManager<K, V> implements TransactionManager {
     public <T> Mono<T> sendOffsets(Map<TopicPartition, OffsetAndMetadata> offsets, String consumerGroupId) {
         return producerMono.flatMap(producer -> Mono.fromRunnable(() -> {
             if (!offsets.isEmpty()) {
-                producer.sendOffsetsToTransaction(offsets, consumerGroupId);
+                producer.sendOffsetsToTransaction(offsets, new ConsumerGroupMetadata(consumerGroupId));
                 DefaultKafkaSender.log.trace("Sent offsets to transaction for producer {}, offsets: {}", senderOptions.transactionalId(), offsets);
             }
         }));

--- a/src/test/java/reactor/kafka/AbstractKafkaTest.java
+++ b/src/test/java/reactor/kafka/AbstractKafkaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -275,7 +275,7 @@ public abstract class AbstractKafkaTest {
             )
         ) {
             DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(Arrays.asList(topic));
-            TopicDescription topicDescription = describeTopicsResult.values().get(topic).get(10, TimeUnit.SECONDS);
+            TopicDescription topicDescription = describeTopicsResult.topicNameValues().get(topic).get(10, TimeUnit.SECONDS);
 
             TopicPartitionInfo partitionInfo = topicDescription.partitions().get(partition);
 

--- a/src/test/java/reactor/kafka/mock/MockConsumer.java
+++ b/src/test/java/reactor/kafka/mock/MockConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InvalidOffsetException;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
 import reactor.kafka.receiver.ReceiverOptions;
 import reactor.kafka.receiver.internals.ConsumerFactory;
@@ -239,7 +240,7 @@ public class MockConsumer extends org.apache.kafka.clients.consumer.MockConsumer
                     Message message = log.get((int) offset);
                     ConsumerRecord<Integer, String> record = new ConsumerRecord<Integer, String>(partition.topic(), partition.partition(), offset,
                             message.timestamp(), TimestampType.CREATE_TIME,
-                            0, 4, message.value().length(), message.key(), message.value());
+                            0, 4, message.key(), message.value(), new RecordHeaders(), Optional.empty());
                     records.get(partition).add(record);
                     offsets.put(partition, offset + 1);
                     if (++count == maxPollRecords)
@@ -344,18 +345,6 @@ public class MockConsumer extends org.apache.kafka.clients.consumer.MockConsumer
                 return 0L;
             }
             return offsets.get(partition);
-        } finally {
-            release();
-        }
-    }
-
-    @Override
-    @Deprecated
-    public OffsetAndMetadata committed(TopicPartition partition) {
-        acquire();
-        try {
-            Long offset = cluster.committedOffset(receiverOptions.groupId(), partition);
-            return offset == null ? null : new OffsetAndMetadata(offset);
         } finally {
             release();
         }

--- a/src/test/java/reactor/kafka/mock/MockProducer.java
+++ b/src/test/java/reactor/kafka/mock/MockProducer.java
@@ -30,11 +30,13 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import reactor.kafka.sender.SenderOptions;
 import reactor.kafka.sender.internals.ProducerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.lang.Math.toIntExact;
 import static org.junit.Assert.assertTrue;
 
 public class MockProducer implements Producer<Integer, String> {
@@ -57,6 +60,7 @@ public class MockProducer implements Producer<Integer, String> {
     private final AtomicInteger inFlightCount;
     public final AtomicInteger sendCount = new AtomicInteger();
     private final Uuid clientInstanceId = Uuid.randomUuid();
+    private final List<KafkaMetric> addedMetrics = new ArrayList<>();
     private SenderOptions<Integer, String> senderOptions;
     private long sendDelayMs;
     private boolean closed;
@@ -178,7 +182,7 @@ public class MockProducer implements Producer<Integer, String> {
         } else {
             try {
                 long offset = cluster.appendMessage(record, !senderOptions.isTransactional());
-                RecordMetadata metadata = new RecordMetadata(topicPartition, 0, offset, System.currentTimeMillis(), 0L, 4, record.value().length());
+                RecordMetadata metadata = new RecordMetadata(topicPartition, 0, toIntExact(offset), System.currentTimeMillis(), 4, record.value().length());
                 callback.onCompletion(metadata, null);
                 return metadata;
             } catch (Exception e) {
@@ -204,12 +208,6 @@ public class MockProducer implements Producer<Integer, String> {
         verifyTransactionsInitialized();
         this.transactionInFlight = true;
         this.beginCount++;
-    }
-
-    @Override
-    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
-                                         String consumerGroupId) throws ProducerFencedException {
-        sendOffsetsToTransaction(offsets, new ConsumerGroupMetadata(consumerGroupId));
     }
 
     @Override
@@ -249,6 +247,20 @@ public class MockProducer implements Producer<Integer, String> {
         this.transactionInFlight = false;
         cluster.abortTransaction();
         this.abortCount++;
+    }
+
+    @Override
+    public void registerMetricForSubscription(KafkaMetric metric) {
+        addedMetrics.add(metric);
+    }
+
+    @Override
+    public void unregisterMetricFromSubscription(KafkaMetric metric) {
+        addedMetrics.remove(metric);
+    }
+
+    public List<KafkaMetric> addedMetrics() {
+        return Collections.unmodifiableList(addedMetrics);
     }
 
     public void fenceProducer() {

--- a/src/test/java/reactor/kafka/mock/MockProducer.java
+++ b/src/test/java/reactor/kafka/mock/MockProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.errors.ProducerFencedException;
@@ -55,6 +56,7 @@ public class MockProducer implements Producer<Integer, String> {
     private final MockCluster cluster;
     private final AtomicInteger inFlightCount;
     public final AtomicInteger sendCount = new AtomicInteger();
+    private final Uuid clientInstanceId = Uuid.randomUuid();
     private SenderOptions<Integer, String> senderOptions;
     private long sendDelayMs;
     private boolean closed;
@@ -130,6 +132,11 @@ public class MockProducer implements Producer<Integer, String> {
     @Override
     public Map<MetricName, ? extends Metric> metrics() {
         return new HashMap<>();
+    }
+
+    @Override
+    public Uuid clientInstanceId(Duration timeout) {
+        return clientInstanceId;
     }
 
     @Override

--- a/src/test/java/reactor/kafka/receiver/internals/ConsumerEventLoopTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/ConsumerEventLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -37,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -82,7 +84,7 @@ public class ConsumerEventLoopTest {
         partitions.add(tp);
         Map<TopicPartition, List<ConsumerRecord>> record = new HashMap<>();
         record.put(tp, Collections.singletonList(
-                new ConsumerRecord("test", 0, 0, 0, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, null)));
+                new ConsumerRecord("test", 0, 0, 0, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, null, null, new RecordHeaders(), Optional.empty())));
         ConsumerRecords records = new ConsumerRecords(record);
         CountDownLatch latch = new CountDownLatch(2);
         AtomicBoolean paused = new AtomicBoolean();

--- a/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
+++ b/src/test/java/reactor/kafka/receiver/internals/MockReceiverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/reactor/kafka/sender/internals/MockSenderTest.java
+++ b/src/test/java/reactor/kafka/sender/internals/MockSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -856,7 +856,7 @@ public class MockSenderTest {
                 RecordMetadata metadata = null;
                 Exception e = null;
                 if (!fail)
-                    metadata = new RecordMetadata(partition, 0, partitionResponses.size(), 0, 0L, 0, 0);
+                    metadata = new RecordMetadata(partition, 0, partitionResponses.size(), 0, 0, 0);
                 else
                     e = new InvalidTopicException("Topic not found: " + topic);
                 partitionResponses.add(new Response<>(metadata, e, correlation));

--- a/src/test/java/reactor/kafka/util/ConsumerDelegate.java
+++ b/src/test/java/reactor/kafka/util/ConsumerDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -194,6 +195,11 @@ public class ConsumerDelegate<K, V> implements Consumer<K, V> {
     @Override
     public Map<TopicPartition, OffsetAndMetadata> committed(Set<TopicPartition> partitions, Duration timeout) {
         return delegate.committed(partitions, timeout);
+    }
+
+    @Override
+    public Uuid clientInstanceId(Duration timeout) {
+        return delegate.clientInstanceId(timeout);
     }
 
     @Override

--- a/src/test/java/reactor/kafka/util/ConsumerDelegate.java
+++ b/src/test/java/reactor/kafka/util/ConsumerDelegate.java
@@ -23,11 +23,13 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.clients.consumer.SubscriptionPattern;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metrics.KafkaMetric;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -95,14 +97,18 @@ public class ConsumerDelegate<K, V> implements Consumer<K, V> {
     }
 
     @Override
-    public void unsubscribe() {
-        delegate.unsubscribe();
+    public void subscribe(SubscriptionPattern pattern, ConsumerRebalanceListener callback) {
+        delegate.subscribe(pattern, callback);
     }
 
     @Override
-    @Deprecated
-    public ConsumerRecords<K, V> poll(long timeout) {
-        return delegate.poll(timeout);
+    public void subscribe(SubscriptionPattern pattern) {
+        delegate.subscribe(pattern);
+    }
+
+    @Override
+    public void unsubscribe() {
+        delegate.unsubscribe();
     }
 
     @Override
@@ -146,6 +152,16 @@ public class ConsumerDelegate<K, V> implements Consumer<K, V> {
     }
 
     @Override
+    public void registerMetricForSubscription(KafkaMetric metric) {
+
+    }
+
+    @Override
+    public void unregisterMetricFromSubscription(KafkaMetric metric) {
+
+    }
+
+    @Override
     public void seek(TopicPartition partition, long offset) {
         delegate.seek(partition, offset);
     }
@@ -173,18 +189,6 @@ public class ConsumerDelegate<K, V> implements Consumer<K, V> {
     @Override
     public long position(TopicPartition partition, Duration timeout) {
         return delegate.position(partition, timeout);
-    }
-
-    @Override
-    @Deprecated
-    public OffsetAndMetadata committed(TopicPartition partition) {
-        return delegate.committed(partition);
-    }
-
-    @Override
-    @Deprecated
-    public OffsetAndMetadata committed(TopicPartition partition, Duration timeout) {
-        return delegate.committed(partition, timeout);
     }
 
     @Override


### PR DESCRIPTION
This is a draft attempt at updating `kafka-clients` to the latest version (4.0.0).

Fixes #420