### PR TITLE
Bump kafka-clients to 3.9.1 and Testcontainers Kafka module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ reactiveStreams = "1.0.3"
 micrometerTracing = '1.1.4'
 
 [libraries]
-kafka = "org.apache.kafka:kafka-clients:3.6.0"
+kafka = "org.apache.kafka:kafka-clients:3.9.1"
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactorCore" }
 reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "reactorCore" }
 
@@ -31,7 +31,7 @@ powermock-core = { module = "org.powermock:powermock-core", version.ref = "power
 powermock-junit = { module = "org.powermock:powermock-module-junit4", version.ref = "powermock" }
 powermock-mockito = { module = "org.powermock:powermock-api-mockito2", version.ref = "powermock" }
 slf4j = "org.slf4j:slf4j-api:1.7.36"
-testcontainers = "org.testcontainers:kafka:1.19.0"
+testcontainers = "org.testcontainers:kafka:1.21.3"
 micrometer-observation = { module = "io.micrometer:micrometer-observation", version.ref = "micrometer" }
 micrometer-tracing-test = { module = "io.micrometer:micrometer-tracing-integration-test", version.ref = "micrometerTracing" }
 

--- a/src/test/java/reactor/kafka/mock/MockProducer.java
+++ b/src/test/java/reactor/kafka/mock/MockProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.errors.ProducerFencedException;
@@ -242,6 +243,11 @@ public class MockProducer implements Producer<Integer, String> {
         this.transactionInFlight = false;
         cluster.abortTransaction();
         this.abortCount++;
+    }
+
+    @Override
+    public Uuid clientInstanceId(Duration timeout) {
+        throw new UnsupportedOperationException("clientInstanceId not supported");
     }
 
     public void fenceProducer() {

--- a/src/test/java/reactor/kafka/util/ConsumerDelegate.java
+++ b/src/test/java/reactor/kafka/util/ConsumerDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -318,5 +319,10 @@ public class ConsumerDelegate<K, V> implements Consumer<K, V> {
     @Override
     public void wakeup() {
         delegate.wakeup();
+    }
+
+    @Override
+    public Uuid clientInstanceId(Duration duration) {
+        return delegate.clientInstanceId(duration);
     }
 }


### PR DESCRIPTION
Upon community request, this PR upgrades the kafka-clients dependency to 3.9.1.

Resolves #409 