### PR TITLE
Update libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ micrometerTracing = '1.1.4'
 
 [libraries]
 kafka = "org.apache.kafka:kafka-clients:3.9.1"
+lz4 = "org.lz4:lz4-java:1.10.1"
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactorCore" }
 reactor-test = { module = "io.projectreactor:reactor-test", version.ref = "reactorCore" }
 


### PR DESCRIPTION
Is it possible to bump the version of kafka client? This one is quite old.

Maybe by forcing a version on lz4?